### PR TITLE
fix(community rules): Close modal after upload

### DIFF
--- a/ui/src/components/Common/CommunityRuleModal/index.tsx
+++ b/ui/src/components/Common/CommunityRuleModal/index.tsx
@@ -108,6 +108,11 @@ const CommunityRuleModal = (props: ICommunityRuleModal) => {
     props.onCancel()
   }
 
+  const handleUpload = () => {
+    setUploadMyRules(false)
+    props.onCancel()
+  }
+
   const handleClick = (id: number) => {
     if (clickedRule !== id) {
       setClickedRule(id)
@@ -303,7 +308,7 @@ const CommunityRuleModal = (props: ICommunityRuleModal) => {
         {uploadMyRules ? (
           <CommunityRuleUpload
             onCancel={() => setUploadMyRules(false)}
-            onSubmit={() => setUploadMyRules(false)}
+            onSubmit={handleUpload}
             type={props.type}
             rules={props.currentRules ? props.currentRules : []}
           />

--- a/ui/src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
+++ b/ui/src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
@@ -107,7 +107,7 @@ const CommunityRuleUpload = (props: ICommunityRuleUpload) => {
             backgroundClickable={false}
             onCancel={() => {
               setThanksModal(false)
-              props.onCancel()
+              props.onSubmit()
             }}
             cancelText={'Close'}
             title={'Upload Successful'}


### PR DESCRIPTION
Closes the modal after a rule upload. This way we force to user to refetch all rules when reopening the modal.