### PR TITLE
fix: do not create a supervisord.log file

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,7 +1,7 @@
 [supervisord]
 nodaemon=true
-logfile=/dev/null
-logfile_maxbytes=0
+logfile=/opt/data
+logfile_maxbytes=20971520
 user=node
 
 [program:server]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,6 @@
 [supervisord]
 nodaemon=true
-logfile=/opt/data
+logfile=/opt/data/
 logfile_maxbytes=20971520
 user=node
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,7 @@
 [supervisord]
 nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
 user=node
 
 [program:server]

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,6 @@
 [supervisord]
 nodaemon=true
-logfile=/opt/data/
+logfile=/opt/data/supervisord.log
 logfile_maxbytes=20971520
 user=node
 


### PR DESCRIPTION
This allows us to mount the root filesystem as read-only. 

[See here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/](https://kubesec.io/basics/containers-securitycontext-readonlyrootfilesystem-true/)