### PR TITLE
fix(docker): create .cache directory in expected location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,9 @@ RUN corepack install && \
 
 USER node
 
+# Picked up for Node's .cache directory.
+ENV HOME=/
+
 EXPOSE 6246
 
 VOLUME [ "/opt/data" ]


### PR DESCRIPTION
Node appears to want to access /opt/app/.cache, but when running as non-default user the /opt/app isn't writable. We attempted to create a more permissive directory during build to accommodate this but the location was slightly wrong.

I can reproduce the issue by running `podman run -u 1001:1001 docker.io/jorenn92/maintainerr:latest`, which gives me a constantly respawning daemon and logs like this:

```
2024-02-04 12:42:18,185 INFO supervisord started with pid 1
2024-02-04 12:42:19,188 INFO spawned: 'docs' with pid 2
2024-02-04 12:42:19,189 INFO spawned: 'server' with pid 3
2024-02-04 12:42:19,191 INFO spawned: 'ui' with pid 4
Internal Error: EACCES: permission denied, mkdir '/opt/app/.cache'
Error: EACCES: permission denied, mkdir '/opt/app/.cache'
2024-02-04 12:42:19,595 WARN exited: docs (exit status 1; not expected)
2024-02-04 12:42:19,596 WARN exited: server (exit status 1; not expected)
```

It looked like a typo to me, but I've not used Node before so may be missing some subtleties on how it works.