### PR TITLE
fix: Resolve SQL error during Plex collection recreation

### DIFF
--- a/server/src/modules/collections/collections.service.ts
+++ b/server/src/modules/collections/collections.service.ts
@@ -994,11 +994,6 @@ export class CollectionsService {
       this.infoLogger(`Creating collection in Plex..`);
       const resp = await this.plexApi.createCollection(collectionData);
       if (resp?.ratingKey) {
-        this.addLogRecord(
-          { id: collectionData.collectionId } as Collection,
-          'Plex collection created',
-          ECollectionLogType.COLLECTION,
-        );
         return resp;
       } else {
         return resp[0];


### PR DESCRIPTION
Previously, an SQL error could occur when recreating a collection in Plex. This commit addresses the issue, ensuring smooth collection recreation without encountering SQL errors.