### PR TITLE
fix: Automatically prepend https for Overseerr, Sonarr and Radarr when using port 443

### DIFF
--- a/ui/src/components/Settings/Overseerr/index.tsx
+++ b/ui/src/components/Settings/Overseerr/index.tsx
@@ -79,7 +79,10 @@ const OverseerrSettings = () => {
         ? hostnameRef.current.value
         : hostnameRef.current.value.includes('https://')
           ? hostnameRef.current.value
-          : 'http://' + hostnameRef.current.value
+        : portRef.current.value == '443'
+        ? 'https://' + hostnameRef.current.value
+        : 'http://' + hostnameRef.current.value
+
       const payload = {
         overseerr_url: addPortToUrl(hostnameVal, +portRef.current.value),
         overseerr_api_key: apiKeyRef.current.value,

--- a/ui/src/components/Settings/Radarr/index.tsx
+++ b/ui/src/components/Settings/Radarr/index.tsx
@@ -74,10 +74,12 @@ const RadarrSettings = () => {
       portRef.current?.value &&
       apiKeyRef.current?.value
     ) {
-      const hostnameVal = hostnameRef.current.value.includes('http')
+      const hostnameVal = hostnameRef.current.value.includes('http://')
         ? hostnameRef.current.value
-        : hostnameRef.current.value.includes('https')
+        : hostnameRef.current.value.includes('https://')
           ? hostnameRef.current.value
+          : portRef.current.value == '443' ? 
+          'https://' + hostnameRef.current.value
           : 'http://' + hostnameRef.current.value
 
       let radarr_url = `${addPortToUrl(hostnameVal, +portRef.current.value)}`

--- a/ui/src/components/Settings/Sonarr/index.tsx
+++ b/ui/src/components/Settings/Sonarr/index.tsx
@@ -74,10 +74,12 @@ const SonarrSettings = () => {
       portRef.current?.value &&
       apiKeyRef.current?.value
     ) {
-      const hostnameVal = hostnameRef.current.value.includes('http')
+      const hostnameVal = hostnameRef.current.value.includes('http://')
         ? hostnameRef.current.value
-        : hostnameRef.current.value.includes('https')
+        : hostnameRef.current.value.includes('https://')
           ? hostnameRef.current.value
+          : portRef.current.value == '443'
+        ? 'https://' + hostnameRef.current.value
           : 'http://' + hostnameRef.current.value
 
       let url = `${addPortToUrl(hostnameVal, +portRef.current.value)}`


### PR DESCRIPTION
This took me way too long to figure out. Hence this PR to fix this for future me (And everyone else).

Because the fields are labeled as Hostname / IP it wasn't clear you could enter https://hostname in that field (Which technically is a URL, not a hostname).
So I put my hostname and port 443 in the settings, but every time I clicked test it failed.

It wasn't untill I refreshed the page it became clear the hostname was prepended with http:// by default.

This PR fixes this by prepending the hostname with https when using port 443, or http if not.

The includes checks could be combined into one (https always contains http, so no need to check twice), and I've added a condition for port 443.

(First PR here, please let me know if anything is missing)