### PR TITLE
fix: Fixed Radarr file size rule, when 'sizeOnDisk' is not available,…

### DIFF
--- a/server/src/modules/rules/getter/radarr-getter.service.ts
+++ b/server/src/modules/rules/getter/radarr-getter.service.ts
@@ -99,7 +99,9 @@ export class RadarrGetterService {
           case 'fileSize': {
             return movieResponse?.sizeOnDisk
               ? Math.round(movieResponse.sizeOnDisk / 1048576)
-              : null;
+              : movieResponse.movieFile?.size
+                ? Math.round(movieResponse.movieFile.size / 1048576)
+                : null;
           }
           case 'releaseDate': {
             return movieResponse?.physicalRelease &&


### PR DESCRIPTION
… it'll now fall back to movieFile.size