### PR TITLE
auto-stale issues workflow

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,26 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "20 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          exempt-issue-labels: never-stale,bug,enhancement
+          exempt-issue-assignees: jorenn92,ydkmlt84,benscobie
+          stale-issue-label: "stale"
+          close-issue-label: "stale-closed"
+          stale-issue-message: "This issue has been marked stale because it has been 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          debug-only: true


### PR DESCRIPTION
Adding a workflow to auto mark issues as stale after 30 days of no activity, then close them after 14 days of being marked stale.

I also added that it will ignore the bug, never-stale, and enhancement labels. It will also ignore the issue if one of (jorenn92,ydkmlt84,benscobie) have been assigned to the issue.

Currently it is marked with debug-only: true for dry-run purposes.