### PR TITLE
feat: Add base URL to Tautulli settings

### DIFF
--- a/server/src/database/migrations/1728503476668-Update_tautulli_URL.ts
+++ b/server/src/database/migrations/1728503476668-Update_tautulli_URL.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateTautulliURL1728503476668 implements MigrationInterface {
+  name = 'UpdateTautulliURL1728503476668';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE settings SET tautulli_url = rtrim(tautulli_url, '/')`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/server/src/modules/api/tautulli-api/tautulli-api.service.ts
+++ b/server/src/modules/api/tautulli-api/tautulli-api.service.ts
@@ -102,7 +102,7 @@ export class TautulliApiService {
 
   public async init() {
     this.api = new TautulliApi({
-      url: `${this.settings.tautulli_url}api/v2`,
+      url: `${this.settings.tautulli_url}/api/v2`,
       apiKey: `${this.settings.tautulli_api_key}`,
     });
   }

--- a/ui/src/components/Settings/Radarr/index.tsx
+++ b/ui/src/components/Settings/Radarr/index.tsx
@@ -8,7 +8,7 @@ import DocsButton from '../../Common/DocsButton'
 import TestButton from '../../Common/TestButton'
 import {
   addPortToUrl,
-  getArrBaseUrl,
+  getBaseUrl,
   getHostname,
   getPortFromUrl,
   handleSettingsInputChange,
@@ -36,7 +36,7 @@ const RadarrSettings = () => {
 
   useEffect(() => {
     setHostname(getHostname(settingsCtx.settings.radarr_url))
-    setBaseUrl(getArrBaseUrl(settingsCtx.settings.radarr_url))
+    setBaseUrl(getBaseUrl(settingsCtx.settings.radarr_url))
     setPort(getPortFromUrl(settingsCtx.settings.radarr_url))
 
     // @ts-ignore
@@ -45,7 +45,7 @@ const RadarrSettings = () => {
     }
     // @ts-ignore
     baseUrlRef.current = {
-      value: getArrBaseUrl(settingsCtx.settings.radarr_url),
+      value: getBaseUrl(settingsCtx.settings.radarr_url),
     }
     // @ts-ignore
     portRef.current = { value: getPortFromUrl(settingsCtx.settings.radarr_url) }
@@ -78,9 +78,9 @@ const RadarrSettings = () => {
         ? hostnameRef.current.value
         : hostnameRef.current.value.includes('https://')
           ? hostnameRef.current.value
-          : portRef.current.value == '443' ? 
-          'https://' + hostnameRef.current.value
-          : 'http://' + hostnameRef.current.value
+          : portRef.current.value == '443'
+            ? 'https://' + hostnameRef.current.value
+            : 'http://' + hostnameRef.current.value
 
       let radarr_url = `${addPortToUrl(hostnameVal, +portRef.current.value)}`
       radarr_url = radarr_url.endsWith('/')

--- a/ui/src/components/Settings/Sonarr/index.tsx
+++ b/ui/src/components/Settings/Sonarr/index.tsx
@@ -8,7 +8,7 @@ import DocsButton from '../../Common/DocsButton'
 import TestButton from '../../Common/TestButton'
 import {
   getHostname,
-  getArrBaseUrl,
+  getBaseUrl,
   getPortFromUrl,
   addPortToUrl,
   handleSettingsInputChange,
@@ -36,7 +36,7 @@ const SonarrSettings = () => {
 
   useEffect(() => {
     setHostname(getHostname(settingsCtx.settings.sonarr_url))
-    setBaseUrl(getArrBaseUrl(settingsCtx.settings.sonarr_url))
+    setBaseUrl(getBaseUrl(settingsCtx.settings.sonarr_url))
     setPort(getPortFromUrl(settingsCtx.settings.sonarr_url))
 
     // @ts-ignore
@@ -45,7 +45,7 @@ const SonarrSettings = () => {
     }
     // @ts-ignore
     baseUrlRef.current = {
-      value: getArrBaseUrl(settingsCtx.settings.sonarr_url),
+      value: getBaseUrl(settingsCtx.settings.sonarr_url),
     }
     // @ts-ignore
     portRef.current = { value: getPortFromUrl(settingsCtx.settings.sonarr_url) }

--- a/ui/src/utils/SettingsUtils.ts
+++ b/ui/src/utils/SettingsUtils.ts
@@ -52,7 +52,7 @@ export function getHostname(url: string): string | undefined {
   }
 }
 
-export function getArrBaseUrl(url: string): string | undefined {
+export function getBaseUrl(url: string): string | undefined {
   try {
     const urlObject = new URL(url)
     let baseUrl = urlObject.pathname


### PR DESCRIPTION
Resolves #1305

I've added a migration to trim any trailing slash of the tautulli_url as the hostname logic is now the same as Sonarr & Radarr.

I've also removed the ref usage in favour of state. Was there a particular reason for using both as this seems to be common throughout the code base? I've only ever seen state being used for form inputs, unless using a library such as React Hook Form which uses refs.