### PR TITLE
fix: Collection details not showing in Safari

### DIFF
--- a/ui/src/components/Collection/CollectionOverview/index.tsx
+++ b/ui/src/components/Collection/CollectionOverview/index.tsx
@@ -35,7 +35,7 @@ const CollectionOverview = (props: ICollectionOverview) => {
           {props.collections?.map((col) => (
             <li
               key={+col.id!}
-              className="collection relative mb-5 flex h-fit flex-col overflow-hidden rounded-xl bg-zinc-800 bg-cover bg-center p-4 text-zinc-400 shadow ring-1 ring-zinc-700 sm:mb-0 sm:mr-5 xs:w-full"
+              className="collection relative mb-5 flex h-fit flex-col overflow-hidden rounded-xl bg-zinc-800 bg-cover bg-center p-4 text-zinc-400 shadow ring-1 ring-zinc-700 sm:mb-0 sm:mr-5 xs:w-full transform-gpu"
             >
               <CollectionItem
                 key={col.id}


### PR DESCRIPTION
Resolves #1314

overflow-hidden and border-radius don't seem to play nice with each other on Safari. Similar to the issue described here: https://gist.github.com/domske/b66047671c780a238b51c51ffde8d3a0