### PR TITLE
feat: Add envars to control service ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.19 as BUILDER
+FROM node:20-alpine3.19 AS builder
 LABEL Description="Contains the Maintainerr Docker image"
 
 WORKDIR /opt/app/
@@ -64,6 +64,12 @@ ENV NODE_ENV=${NODE_ENV}
 
 ARG DEBUG=false
 ENV DEBUG=${DEBUG}
+
+ARG API_PORT=3001
+ENV API_PORT=${API_PORT}
+
+ARG UI_PORT=6246
+ENV UI_PORT=${UI_PORT}
 
 # Hash of the last GIT commit
 ARG GIT_SHA

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ services:
         environment:
           - TZ=Europe/Brussels
 #      - DEBUG=true # uncomment to enable debug logs
+#      - UI_PORT=6247 # uncomment to change the UI port (default 6246). Useful if you're on a network where the port is already in use
+#      - API_PORT=3002 # uncomment to change the API port (default 3001). Useful if you're on a network where the port is already in use
         ports:
           - 6246:6246
         restart: unless-stopped

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -70,7 +70,9 @@ async function bootstrap() {
   // End Winston logger config
 
   app.enableCors({ origin: true });
-  await app.listen(3001);
+
+  const apiPort = process.env.API_PORT || 3001;
+  await app.listen(apiPort);
 }
 
 function createDataDirectoryStructure() {

--- a/server/src/modules/api/internal-api/internal-api.service.ts
+++ b/server/src/modules/api/internal-api/internal-api.service.ts
@@ -13,8 +13,10 @@ export class InternalApiService {
   ) {}
 
   public async init() {
+    const apiPort = process.env.API_PORT || 3001;
+
     this.api = new InternalApi({
-      url: `http://localhost:3001/api/`,
+      url: `http://localhost:${apiPort}/api/`,
       apiKey: `${this.settings.apikey}`,
     });
   }

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -12,7 +12,7 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:ui]
-environment=PORT=6246,HOSTNAME=::
+environment=PORT=%(ENV_UI_PORT)s,HOSTNAME=::
 command=yarn node /opt/app/ui/server.js
 autorestart=true
 startretries=100

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -12,14 +12,6 @@ const nextConfig = {
       },
     ],
   },
-  async rewrites() {
-    return [
-      {
-        source: '/api/:path*',
-        destination: 'http://localhost:3001/api/:path*',
-      },
-    ]
-  },
   async redirects() {
     return [
       {

--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const apiPort = process.env.API_PORT || 3001
+
+export function middleware(request: NextRequest) {
+  const destination = new URL(`http://localhost:${apiPort}`)
+  const url = request.nextUrl.clone()
+  url.host = destination.host
+  url.port = destination.port
+  return NextResponse.rewrite(url)
+}
+
+export const config = {
+  matcher: '/api/:path*',
+}


### PR DESCRIPTION
For feature request: https://features.maintainerr.info/posts/41/pass-in-node-port-as-an-environment-variable-in-docker-compose

We have to use next.js middleware here as next.config.js is build-time config.