### PR TITLE
chore: Only auto merge patch & minor version changes

### DIFF
--- a/.github/workflows/dependabot_merge.yml
+++ b/.github/workflows/dependabot_merge.yml
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ contains(github.event.pull_request.title, 'bump')}}
+        if: ${{ contains(github.event.pull_request.title, 'bump')}} && (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor')
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
Major changes will sometimes require some code changes. Most of these will be picked up by the build failing but that's not always the case like here: https://github.com/jorenn92/Maintainerr/pull/1340

There's also some merit in holding off using a new major release like https://github.com/jorenn92/Maintainerr/pull/1336 as from experience nextjs is initially pretty unstable.