### PR TITLE
chore: Add issue comment workflow to push PRs to Docker repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   semantic-release:
-    if: ${{ github.triggering_actor == github.repository_owner }}
     name: Tag and release latest version
     runs-on: ubuntu-22.04
     steps:
@@ -23,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -45,7 +44,7 @@ jobs:
           fi
 
   build-docker-image:
-    if: ${{ github.triggering_actor == github.repository_owner && github.event.inputs.with-docker-images == 'true' }}
+    if: ${{ github.event.inputs.with-docker-images == 'true' }}
     name: Build and push docker images
     needs: semantic-release
     runs-on: ubuntu-latest

--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -1,0 +1,79 @@
+name: "Release PR"
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+jobs:
+  build-docker-image:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/release-pr') }} && ${{ github.event.issue.state }} == "open" && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER')
+    name: Build and push docker images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set outputs
+        id: vars
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            jorenn92/maintainerr
+            ghcr.io/jorenn92/maintainerr
+          tags: |
+            type=raw,value=pr-${{ github.event.issue.number }}
+          labels: org.opencontainers.image.revision=${{ steps.vars.outputs.sha }}
+
+      - name: Log in to GitHub Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME  }}
+          password: ${{ secrets.DOCKERHUB_TOKEN  }}
+
+      - name: Build & Push docker images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            GIT_SHA=${{ steps.vars.outputs.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Notify of release
+        uses: mshick/add-pr-comment@v2
+        if: always()
+        with:
+          allow-repeats: true
+          message-success: |
+            Released to `jorenn92/maintainerr:pr-${{ github.event.issue.number }}` :rocket:
+          message-failure: |
+            :bangbang: There was an error trying to release the PR.
+          issue: ${{ github.event.issue.number }}


### PR DESCRIPTION
Adding the comment `/release-pr` to a PR will build and push it to the Docker registries. The tag it will use is `pr-{prNumber}`, in this PRs case `pr-1359`.

A comment will be added on success/fail:
![image](https://github.com/user-attachments/assets/219aafe2-3004-43d5-b986-7979416c75b6)

The workflow is limited to collaborators and the owner.

I've also removed the restriction on the release workflow which will allow me to push releases out. By default only users with write access to the repo can run actions anyway.

At some point I'd like to create a scheduled workflow to remove old PR tags to keep the registry a bit cleaner.