### PR TITLE
chore: change develop workflow to develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: weekly
       time: "20:00"
     open-pull-requests-limit: 10
+    target-branch: develop
     ignore:
       - dependency-name: "@heroicons/react"
       - dependency-name: "chalk"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: "Build"
 on:
   push:
     branches:
-      - "main"
+      - "develop"
   pull_request:
     branches:
-      - "main"
+      - "develop"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/run_jest_tests.yml
+++ b/.github/workflows/run_jest_tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - "develop"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Added a develop branch to the repo so that we only build new "develop" images when a PR is raised on the develop branch. Changed dependabot target branch to the develop branch. 

The idea is to only push something to the main branch when we are making a release. All new PRs should be going to the develop  branch, from a feature branch.