### PR TITLE
fix: Handling collections & Sonarr media existence check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
+++ b/server/src/modules/api/servarr-api/helpers/sonarr.helper.ts
@@ -370,6 +370,13 @@ export class SonarrApi extends ServarrApi<{
           }
         }
       }
+
+      this.logger.log(
+        `Unmonitored ${
+          typeof type === 'number' ? `season ${type}` : 'seasons'
+        } from Sonarr show with ID ${seriesId}`,
+      );
+
       return data;
     } catch (e) {
       this.logger.log("Couldn't unmonitor/delete. Does it exist in sonarr?", {
@@ -379,11 +386,6 @@ export class SonarrApi extends ServarrApi<{
       });
       this.logger.debug(e);
     }
-    this.logger.log(
-      `Unmonitored ${
-        typeof type === 'number' ? `season ${type}` : 'seasons'
-      } from Sonarr show with ID ${seriesId}`,
-    );
   }
 
   private buildSeasonList(

--- a/server/src/modules/api/servarr-api/servarr.service.ts
+++ b/server/src/modules/api/servarr-api/servarr.service.ts
@@ -9,8 +9,8 @@ import { SonarrSettingRawDto } from "../../settings/dto's/sonarr-setting.dto";
 @Injectable()
 export class ServarrService {
   SonarrApi: SonarrApi;
-  private radarrApiCache?: Record<string, RadarrApi> = {};
-  private sonarrApiCache?: Record<string, SonarrApi> = {};
+  private radarrApiCache: Record<string, RadarrApi> = {};
+  private sonarrApiCache: Record<string, SonarrApi> = {};
 
   constructor(
     @Inject(forwardRef(() => SettingsService))
@@ -27,7 +27,7 @@ export class ServarrService {
       if (!this.sonarrApiCache[id]) {
         const setting = await this.settings.getSonarrSetting(id);
 
-        if (!('id' in setting)) {
+        if (setting == null || !('id' in setting)) {
           throw new Error('Sonarr setting not found');
         }
 
@@ -57,7 +57,7 @@ export class ServarrService {
       if (!this.radarrApiCache[id]) {
         const setting = await this.settings.getRadarrSetting(id);
 
-        if (!('id' in setting)) {
+        if (setting == null || !('id' in setting)) {
           throw new Error('Radarr setting not found');
         }
 

--- a/server/src/modules/collections/collection-worker.service.ts
+++ b/server/src/modules/collections/collection-worker.service.ts
@@ -256,7 +256,7 @@ export class CollectionWorkerService extends TaskBase {
 
         if (tvdbId) {
           let sonarrMedia = await sonarrApiClient.getSeriesByTvdbId(tvdbId);
-          if (sonarrMedia) {
+          if (sonarrMedia?.id) {
             switch (collection.arrAction) {
               case ServarrAction.DELETE:
                 switch (collection.type) {
@@ -322,12 +322,16 @@ export class CollectionWorkerService extends TaskBase {
                       'all',
                       false,
                     );
-                    // unmonitor show
-                    sonarrMedia.monitored = false;
-                    sonarrApiClient.updateSeries(sonarrMedia);
-                    this.infoLogger(
-                      `[Sonarr] Unmonitored show '${sonarrMedia.title}'`,
-                    );
+
+                    if (sonarrMedia) {
+                      // unmonitor show
+                      sonarrMedia.monitored = false;
+                      sonarrApiClient.updateSeries(sonarrMedia);
+                      this.infoLogger(
+                        `[Sonarr] Unmonitored show '${sonarrMedia.title}'`,
+                      );
+                    }
+
                     break;
                 }
                 break;
@@ -360,12 +364,16 @@ export class CollectionWorkerService extends TaskBase {
                       'all',
                       true,
                     );
-                    // unmonitor show
-                    sonarrMedia.monitored = false;
-                    sonarrApiClient.updateSeries(sonarrMedia);
-                    this.infoLogger(
-                      `[Sonarr] Unmonitored show '${sonarrMedia.title}' and removed all episodes`,
-                    );
+
+                    if (sonarrMedia) {
+                      // unmonitor show
+                      sonarrMedia.monitored = false;
+                      sonarrApiClient.updateSeries(sonarrMedia);
+                      this.infoLogger(
+                        `[Sonarr] Unmonitored show '${sonarrMedia.title}' and removed all episodes`,
+                      );
+                    }
+
                     break;
                 }
                 break;
@@ -399,12 +407,16 @@ export class CollectionWorkerService extends TaskBase {
                       'existing',
                       true,
                     );
-                    // unmonitor show
-                    sonarrMedia.monitored = false;
-                    sonarrApiClient.updateSeries(sonarrMedia);
-                    this.infoLogger(
-                      `[Sonarr] Unmonitored show '${sonarrMedia.title}' and Removed exisiting episodes`,
-                    );
+
+                    if (sonarrMedia) {
+                      // unmonitor show
+                      sonarrMedia.monitored = false;
+                      sonarrApiClient.updateSeries(sonarrMedia);
+                      this.infoLogger(
+                        `[Sonarr] Unmonitored show '${sonarrMedia.title}' and Removed exisiting episodes`,
+                      );
+                    }
+
                     break;
                 }
                 break;

--- a/server/src/modules/collections/collection-worker.service.ts
+++ b/server/src/modules/collections/collection-worker.service.ts
@@ -143,12 +143,12 @@ export class CollectionWorkerService extends TaskBase {
 
     this.collectionService.saveCollection(collection);
 
-    const radarrApiClient = collection.radarrSettings.id
-      ? await this.servarrApi.getRadarrApiClient(collection.radarrSettings.id)
+    const radarrApiClient = collection.radarrSettingsId
+      ? await this.servarrApi.getRadarrApiClient(collection.radarrSettingsId)
       : undefined;
 
-    const sonarrApiClient = collection.sonarrSettings.id
-      ? await this.servarrApi.getSonarrApiClient(collection.sonarrSettings.id)
+    const sonarrApiClient = collection.sonarrSettingsId
+      ? await this.servarrApi.getSonarrApiClient(collection.sonarrSettingsId)
       : undefined;
 
     if (plexLibrary.type === 'movie') {


### PR DESCRIPTION
- Ensure that .sh files have LF line endings. Executing a .sh file with CRLF line breaks will not work.
- I broke handling of media in my multi *arr work as I was attempting to check the related radarr & sonarr setting IDs via the child collection. This would never work as you can only have one or none. I'm now checking the setting ID on the collection itself.
- We were logging "Unmonitored x from Sonarr show with ID x" even when the call failed
- Check that the returned Sonarr media has an ID before performing any actions on it. getSeriesByTvdbId() always returns a result for a valid TVDB ID, it's just that the fallback API call we make doesn't return an ID.
- Check that the unmonitoring seasons call worked before attempting to unmonitor the series. An exception could be thrown here which would break the collection worker job and leave it stuck running.