### PR TITLE
fix: __PATH_PREFIX__ not replaced when using user directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,7 @@ RUN corepack install && \
     # This is required for docker user directive to work
     chmod 777 /opt && \
     chmod 777 /opt/app/start.sh && \
+    chmod 777 -R /opt/app/ui && \
     mkdir -m 777 /.cache  && \
     mkdir -pm 777 /opt/app/ui/.next/cache && \
     chown -R node:node /opt/app/ui/.next/cache


### PR DESCRIPTION
Files were owned by node:node with 755. If you override the user then they won't have permission to replace `__PATH_PREFIX__` on startup. This change makes the UI folder writable by anybody. At first I didn't like this, but as it was 755 before then the node user could already write files. Really this is no worse as we're in a container.