### PR TITLE
feat: Add "Original Language" rule to Sonarr & Radarr

### DIFF
--- a/server/src/database/migrations/1733357722729-Remove-default-arr-servers.ts
+++ b/server/src/database/migrations/1733357722729-Remove-default-arr-servers.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveDefaultArrServers1733357722729
+  implements MigrationInterface
+{
+  name = 'RemoveDefaultArrServers1733357722729';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TABLE "temporary_sonarr_settings" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "serverName" varchar NOT NULL,
+                "url" varchar,
+                "apiKey" varchar
+            )
+        `);
+    await queryRunner.query(`
+            INSERT INTO "temporary_sonarr_settings"("id", "serverName", "url", "apiKey")
+            SELECT "id",
+                "serverName",
+                "url",
+                "apiKey"
+            FROM "sonarr_settings"
+        `);
+    await queryRunner.query(`
+            DROP TABLE "sonarr_settings"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "temporary_sonarr_settings"
+                RENAME TO "sonarr_settings"
+        `);
+    await queryRunner.query(`
+            CREATE TABLE "temporary_radarr_settings" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "serverName" varchar NOT NULL,
+                "url" varchar,
+                "apiKey" varchar
+            )
+        `);
+    await queryRunner.query(`
+            INSERT INTO "temporary_radarr_settings"("id", "serverName", "url", "apiKey")
+            SELECT "id",
+                "serverName",
+                "url",
+                "apiKey"
+            FROM "radarr_settings"
+        `);
+    await queryRunner.query(`
+            DROP TABLE "radarr_settings"
+        `);
+    await queryRunner.query(`
+            ALTER TABLE "temporary_radarr_settings"
+                RENAME TO "radarr_settings"
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/server/src/modules/api/plex-api/plex-api.service.ts
@@ -443,13 +443,13 @@ export class PlexApiService {
   }
 
   public async deleteMediaFromDisk(plexId: number | string): Promise<void> {
-    this.logger.log(
-      `[Plex] Removed media with ID ${plexId} from Plex library.`,
-    );
     try {
       await this.plexClient.deleteQuery({
         uri: `/library/metadata/${plexId}`,
       });
+      this.logger.log(
+        `[Plex] Removed media with ID ${plexId} from Plex library.`,
+      );
     } catch (e) {
       this.logger.warn('Something went wrong while removing media from Plex.', {
         label: 'Plex API',

--- a/server/src/modules/api/servarr-api/interfaces/radarr.interface.ts
+++ b/server/src/modules/api/servarr-api/interfaces/radarr.interface.ts
@@ -14,6 +14,7 @@ export interface RadarrMovieOptions {
 export interface RadarrMovie {
   id: number;
   title: string;
+  originalLanguage: RadarrLanguage;
   isAvailable: boolean;
   monitored: boolean;
   tmdbId: number;
@@ -32,6 +33,11 @@ export interface RadarrMovie {
   digitalRelease: string;
   inCinemas: string;
   tags: number[];
+}
+
+export interface RadarrLanguage {
+  id: number;
+  name: string | null;
 }
 
 export interface RadarrInfo {

--- a/server/src/modules/api/servarr-api/interfaces/sonarr.interface.ts
+++ b/server/src/modules/api/servarr-api/interfaces/sonarr.interface.ts
@@ -83,6 +83,7 @@ export interface SonarrEpisode {
 export interface SonarrSeries {
   title: string;
   sortTitle: string;
+  originalLanguage: SonarrLanguage;
   seasonCount: number;
   status: string;
   overview: string;
@@ -129,6 +130,11 @@ export interface SonarrSeries {
   };
   statistics?: SonarrStatistics;
   ended?: boolean;
+}
+
+export interface SonarrLanguage {
+  id: number;
+  name: string | null;
 }
 
 export interface AddSeriesOptions {

--- a/server/src/modules/collections/collection-worker.service.ts
+++ b/server/src/modules/collections/collection-worker.service.ts
@@ -151,293 +151,300 @@ export class CollectionWorkerService extends TaskBase {
       ? await this.servarrApi.getSonarrApiClient(collection.sonarrSettingsId)
       : undefined;
 
-    if (plexLibrary.type === 'movie') {
-      if (radarrApiClient) {
-        // find tmdbid
-        const tmdbid = media.tmdbId
-          ? media.tmdbId
-          : (
-              await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
-                media.plexId.toString(),
-              )
-            )?.id;
+    if (plexLibrary.type === 'movie' && radarrApiClient) {
+      // find tmdbid
+      const tmdbid = media.tmdbId
+        ? media.tmdbId
+        : (
+            await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
+              media.plexId.toString(),
+            )
+          )?.id;
 
-        if (tmdbid) {
-          const radarrMedia = await radarrApiClient.getMovieByTmdbId(tmdbid);
-          if (radarrMedia && radarrMedia.id) {
-            switch (collection.arrAction) {
-              case ServarrAction.DELETE:
-                await radarrApiClient.deleteMovie(
-                  radarrMedia.id,
-                  true,
-                  collection.listExclusions,
-                );
-                this.infoLogger('Removed movie from filesystem & Radarr');
-                break;
-              case ServarrAction.UNMONITOR:
-                await radarrApiClient.unmonitorMovie(radarrMedia.id, false);
-                this.infoLogger('Unmonitored movie in Radarr');
-                break;
-              case ServarrAction.UNMONITOR_DELETE_ALL:
-                await radarrApiClient.unmonitorMovie(radarrMedia.id, true);
-                this.infoLogger('Unmonitored movie in Radarr & removed files');
-                break;
-              case ServarrAction.UNMONITOR_DELETE_EXISTING:
-                await radarrApiClient.deleteMovie(
-                  radarrMedia.id,
-                  true,
-                  collection.listExclusions,
-                );
-                this.infoLogger('Removed movie from filesystem & Radarr');
-                break;
-            }
-          } else {
-            if (collection.arrAction !== ServarrAction.UNMONITOR) {
-              this.plexApi.deleteMediaFromDisk(media.plexId.toString());
-              this.infoLogger(
-                `Couldn't find movie with tmdb id ${tmdbid} in Radarr, so no Radarr action was taken for movie with Plex ID ${media.plexId}. But the movie was removed from the filesystem`,
+      if (tmdbid) {
+        const radarrMedia = await radarrApiClient.getMovieByTmdbId(tmdbid);
+        if (radarrMedia && radarrMedia.id) {
+          switch (collection.arrAction) {
+            case ServarrAction.DELETE:
+              await radarrApiClient.deleteMovie(
+                radarrMedia.id,
+                true,
+                collection.listExclusions,
               );
-            } else {
-              this.infoLogger(
-                `Radarr unmonitor action was not possible, couldn't find movie with tmdb id ${tmdbid} in Radarr. No action was taken for movie with Plex ID ${media.plexId}`,
+              this.infoLogger('Removed movie from filesystem & Radarr');
+              break;
+            case ServarrAction.UNMONITOR:
+              await radarrApiClient.unmonitorMovie(radarrMedia.id, false);
+              this.infoLogger('Unmonitored movie in Radarr');
+              break;
+            case ServarrAction.UNMONITOR_DELETE_ALL:
+              await radarrApiClient.unmonitorMovie(radarrMedia.id, true);
+              this.infoLogger('Unmonitored movie in Radarr & removed files');
+              break;
+            case ServarrAction.UNMONITOR_DELETE_EXISTING:
+              await radarrApiClient.deleteMovie(
+                radarrMedia.id,
+                true,
+                collection.listExclusions,
               );
-            }
+              this.infoLogger('Removed movie from filesystem & Radarr');
+              break;
           }
         } else {
-          this.infoLogger(
-            `Couldn't find correct tmdb id. No action taken for movie with Plex ID: ${media.plexId}. Please check this movie manually`,
-          );
+          if (collection.arrAction !== ServarrAction.UNMONITOR) {
+            this.plexApi.deleteMediaFromDisk(media.plexId.toString());
+            this.infoLogger(
+              `Couldn't find movie with tmdb id ${tmdbid} in Radarr, so no Radarr action was taken for movie with Plex ID ${media.plexId}. But the movie was removed from the filesystem`,
+            );
+          } else {
+            this.infoLogger(
+              `Radarr unmonitor action was not possible, couldn't find movie with tmdb id ${tmdbid} in Radarr. No action was taken for movie with Plex ID ${media.plexId}`,
+            );
+          }
         }
+      } else {
+        this.infoLogger(
+          `Couldn't find correct tmdb id. No action taken for movie with Plex ID: ${media.plexId}. Please check this movie manually`,
+        );
       }
-    } else {
-      if (sonarrApiClient) {
-        // get the tvdb id
-        let tvdbId = undefined;
-        switch (collection.type) {
-          case EPlexDataType.SEASONS:
-            plexData = await this.plexApi.getMetadata(media.plexId.toString());
-            tvdbId = await this.tvdbidFinder({
-              ...media,
-              ...{ plexID: plexData.parentRatingKey },
-            });
-            media.tmdbId = media.tmdbId
-              ? media.tmdbId
-              : (
-                  await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
-                    plexData.parentRatingKey,
-                  )
-                )?.id;
-            break;
-          case EPlexDataType.EPISODES:
-            plexData = await this.plexApi.getMetadata(media.plexId.toString());
-            tvdbId = await this.tvdbidFinder({
-              ...media,
-              ...{ plexID: plexData.grandparentRatingKey },
-            });
-            media.tmdbId = media.tmdbId
-              ? media.tmdbId
-              : (
-                  await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
-                    plexData.grandparentRatingKey.toString(),
-                  )
-                )?.id;
-            break;
-          default:
-            tvdbId = await this.tvdbidFinder(media);
-            media.tmdbId = media.tmdbId
-              ? media.tmdbId
-              : (
-                  await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
-                    media.plexId.toString(),
-                  )
-                )?.id;
-            break;
-        }
+    } else if (plexLibrary.type == 'show' && sonarrApiClient) {
+      // get the tvdb id
+      let tvdbId = undefined;
+      switch (collection.type) {
+        case EPlexDataType.SEASONS:
+          plexData = await this.plexApi.getMetadata(media.plexId.toString());
+          tvdbId = await this.tvdbidFinder({
+            ...media,
+            ...{ plexID: plexData.parentRatingKey },
+          });
+          media.tmdbId = media.tmdbId
+            ? media.tmdbId
+            : (
+                await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
+                  plexData.parentRatingKey,
+                )
+              )?.id;
+          break;
+        case EPlexDataType.EPISODES:
+          plexData = await this.plexApi.getMetadata(media.plexId.toString());
+          tvdbId = await this.tvdbidFinder({
+            ...media,
+            ...{ plexID: plexData.grandparentRatingKey },
+          });
+          media.tmdbId = media.tmdbId
+            ? media.tmdbId
+            : (
+                await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
+                  plexData.grandparentRatingKey.toString(),
+                )
+              )?.id;
+          break;
+        default:
+          tvdbId = await this.tvdbidFinder(media);
+          media.tmdbId = media.tmdbId
+            ? media.tmdbId
+            : (
+                await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
+                  media.plexId.toString(),
+                )
+              )?.id;
+          break;
+      }
 
-        if (tvdbId) {
-          let sonarrMedia = await sonarrApiClient.getSeriesByTvdbId(tvdbId);
-          if (sonarrMedia?.id) {
-            switch (collection.arrAction) {
-              case ServarrAction.DELETE:
-                switch (collection.type) {
-                  case EPlexDataType.SEASONS:
-                    sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                      sonarrMedia.id,
-                      plexData.index,
-                      true,
-                    );
-                    this.infoLogger(
-                      `[Sonarr] Removed season ${plexData.index} from show '${sonarrMedia.title}'`,
-                    );
-                    break;
-                  case EPlexDataType.EPISODES:
-                    await sonarrApiClient.UnmonitorDeleteEpisodes(
-                      sonarrMedia.id,
-                      plexData.parentIndex,
-                      [plexData.index],
-                      true,
-                    );
-                    this.infoLogger(
-                      `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
-                    );
-                    break;
-                  default:
-                    await sonarrApiClient.deleteShow(
-                      sonarrMedia.id,
-                      true,
-                      collection.listExclusions,
-                    );
-                    this.infoLogger(
-                      `Removed show ${sonarrMedia.title}' from Sonarr`,
-                    );
-                    break;
-                }
-                break;
-              case ServarrAction.UNMONITOR:
-                switch (collection.type) {
-                  case EPlexDataType.SEASONS:
-                    sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                      sonarrMedia.id,
-                      plexData.index,
-                      false,
-                    );
-                    this.infoLogger(
-                      `[Sonarr] Unmonitored season ${plexData.index} from show '${sonarrMedia.title}'`,
-                    );
-                    break;
-                  case EPlexDataType.EPISODES:
-                    await sonarrApiClient.UnmonitorDeleteEpisodes(
-                      sonarrMedia.id,
-                      plexData.parentIndex,
-                      [plexData.index],
-                      false,
-                    );
-                    this.infoLogger(
-                      `[Sonarr] Unmonitored season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
-                    );
-                    break;
-                  default:
-                    sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                      sonarrMedia.id,
-                      'all',
-                      false,
-                    );
+      if (tvdbId) {
+        let sonarrMedia = await sonarrApiClient.getSeriesByTvdbId(tvdbId);
+        if (sonarrMedia?.id) {
+          switch (collection.arrAction) {
+            case ServarrAction.DELETE:
+              switch (collection.type) {
+                case EPlexDataType.SEASONS:
+                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+                    sonarrMedia.id,
+                    plexData.index,
+                    true,
+                  );
+                  this.infoLogger(
+                    `[Sonarr] Removed season ${plexData.index} from show '${sonarrMedia.title}'`,
+                  );
+                  break;
+                case EPlexDataType.EPISODES:
+                  await sonarrApiClient.UnmonitorDeleteEpisodes(
+                    sonarrMedia.id,
+                    plexData.parentIndex,
+                    [plexData.index],
+                    true,
+                  );
+                  this.infoLogger(
+                    `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
+                  );
+                  break;
+                default:
+                  await sonarrApiClient.deleteShow(
+                    sonarrMedia.id,
+                    true,
+                    collection.listExclusions,
+                  );
+                  this.infoLogger(
+                    `Removed show ${sonarrMedia.title}' from Sonarr`,
+                  );
+                  break;
+              }
+              break;
+            case ServarrAction.UNMONITOR:
+              switch (collection.type) {
+                case EPlexDataType.SEASONS:
+                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+                    sonarrMedia.id,
+                    plexData.index,
+                    false,
+                  );
+                  this.infoLogger(
+                    `[Sonarr] Unmonitored season ${plexData.index} from show '${sonarrMedia.title}'`,
+                  );
+                  break;
+                case EPlexDataType.EPISODES:
+                  await sonarrApiClient.UnmonitorDeleteEpisodes(
+                    sonarrMedia.id,
+                    plexData.parentIndex,
+                    [plexData.index],
+                    false,
+                  );
+                  this.infoLogger(
+                    `[Sonarr] Unmonitored season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
+                  );
+                  break;
+                default:
+                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+                    sonarrMedia.id,
+                    'all',
+                    false,
+                  );
 
-                    if (sonarrMedia) {
-                      // unmonitor show
-                      sonarrMedia.monitored = false;
-                      sonarrApiClient.updateSeries(sonarrMedia);
-                      this.infoLogger(
-                        `[Sonarr] Unmonitored show '${sonarrMedia.title}'`,
-                      );
-                    }
-
-                    break;
-                }
-                break;
-              case ServarrAction.UNMONITOR_DELETE_ALL:
-                switch (collection.type) {
-                  case EPlexDataType.SEASONS:
-                    sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                      sonarrMedia.id,
-                      plexData.index,
-                      true,
-                    );
+                  if (sonarrMedia) {
+                    // unmonitor show
+                    sonarrMedia.monitored = false;
+                    sonarrApiClient.updateSeries(sonarrMedia);
                     this.infoLogger(
-                      `[Sonarr] Removed season ${plexData.index} from show '${sonarrMedia.title}'`,
+                      `[Sonarr] Unmonitored show '${sonarrMedia.title}'`,
                     );
-                    break;
-                  case EPlexDataType.EPISODES:
-                    await sonarrApiClient.UnmonitorDeleteEpisodes(
-                      sonarrMedia.id,
-                      plexData.parentIndex,
-                      [plexData.index],
-                      true,
-                    );
+                  }
+
+                  break;
+              }
+              break;
+            case ServarrAction.UNMONITOR_DELETE_ALL:
+              switch (collection.type) {
+                case EPlexDataType.SEASONS:
+                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+                    sonarrMedia.id,
+                    plexData.index,
+                    true,
+                  );
+                  this.infoLogger(
+                    `[Sonarr] Removed season ${plexData.index} from show '${sonarrMedia.title}'`,
+                  );
+                  break;
+                case EPlexDataType.EPISODES:
+                  await sonarrApiClient.UnmonitorDeleteEpisodes(
+                    sonarrMedia.id,
+                    plexData.parentIndex,
+                    [plexData.index],
+                    true,
+                  );
+                  this.infoLogger(
+                    `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
+                  );
+                  break;
+                default:
+                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+                    sonarrMedia.id,
+                    'all',
+                    true,
+                  );
+
+                  if (sonarrMedia) {
+                    // unmonitor show
+                    sonarrMedia.monitored = false;
+                    sonarrApiClient.updateSeries(sonarrMedia);
                     this.infoLogger(
-                      `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
+                      `[Sonarr] Unmonitored show '${sonarrMedia.title}' and removed all episodes`,
                     );
-                    break;
-                  default:
-                    sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                      sonarrMedia.id,
-                      'all',
-                      true,
-                    );
+                  }
 
-                    if (sonarrMedia) {
-                      // unmonitor show
-                      sonarrMedia.monitored = false;
-                      sonarrApiClient.updateSeries(sonarrMedia);
-                      this.infoLogger(
-                        `[Sonarr] Unmonitored show '${sonarrMedia.title}' and removed all episodes`,
-                      );
-                    }
+                  break;
+              }
+              break;
+            case ServarrAction.UNMONITOR_DELETE_EXISTING:
+              switch (collection.type) {
+                case EPlexDataType.SEASONS:
+                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+                    sonarrMedia.id,
+                    plexData.index,
+                    true,
+                    true,
+                  );
+                  this.infoLogger(
+                    `[Sonarr] Removed exisiting episodes from season ${plexData.index} from show '${sonarrMedia.title}'`,
+                  );
+                  break;
+                case EPlexDataType.EPISODES:
+                  await sonarrApiClient.UnmonitorDeleteEpisodes(
+                    sonarrMedia.id,
+                    plexData.parentIndex,
+                    [plexData.index],
+                    true,
+                  );
+                  this.infoLogger(
+                    `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
+                  );
+                  break;
+                default:
+                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+                    sonarrMedia.id,
+                    'existing',
+                    true,
+                  );
 
-                    break;
-                }
-                break;
-              case ServarrAction.UNMONITOR_DELETE_EXISTING:
-                switch (collection.type) {
-                  case EPlexDataType.SEASONS:
-                    sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                      sonarrMedia.id,
-                      plexData.index,
-                      true,
-                      true,
-                    );
+                  if (sonarrMedia) {
+                    // unmonitor show
+                    sonarrMedia.monitored = false;
+                    sonarrApiClient.updateSeries(sonarrMedia);
                     this.infoLogger(
-                      `[Sonarr] Removed exisiting episodes from season ${plexData.index} from show '${sonarrMedia.title}'`,
+                      `[Sonarr] Unmonitored show '${sonarrMedia.title}' and Removed exisiting episodes`,
                     );
-                    break;
-                  case EPlexDataType.EPISODES:
-                    await sonarrApiClient.UnmonitorDeleteEpisodes(
-                      sonarrMedia.id,
-                      plexData.parentIndex,
-                      [plexData.index],
-                      true,
-                    );
-                    this.infoLogger(
-                      `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
-                    );
-                    break;
-                  default:
-                    sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                      sonarrMedia.id,
-                      'existing',
-                      true,
-                    );
+                  }
 
-                    if (sonarrMedia) {
-                      // unmonitor show
-                      sonarrMedia.monitored = false;
-                      sonarrApiClient.updateSeries(sonarrMedia);
-                      this.infoLogger(
-                        `[Sonarr] Unmonitored show '${sonarrMedia.title}' and Removed exisiting episodes`,
-                      );
-                    }
-
-                    break;
-                }
-                break;
-            }
-          } else {
-            if (collection.arrAction !== ServarrAction.UNMONITOR) {
-              this.plexApi.deleteMediaFromDisk(plexData.ratingKey);
-              this.infoLogger(
-                `Couldn't find correct tvdb id. No Sonarr action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}. But media item was removed through Plex`,
-              );
-            } else {
-              this.infoLogger(
-                `Couldn't find correct tvdb id. No unmonitor action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}`,
-              );
-            }
+                  break;
+              }
+              break;
           }
         } else {
-          this.infoLogger(
-            `Couldn't find correct tvdb id. No action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}. Please check this show manually`,
-          );
+          if (collection.arrAction !== ServarrAction.UNMONITOR) {
+            this.plexApi.deleteMediaFromDisk(plexData.ratingKey);
+            this.infoLogger(
+              `Couldn't find correct tvdb id. No Sonarr action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}. But media item was removed through Plex`,
+            );
+          } else {
+            this.infoLogger(
+              `Couldn't find correct tvdb id. No unmonitor action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}`,
+            );
+          }
         }
+      } else {
+        this.infoLogger(
+          `Couldn't find correct tvdb id. No action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}. Please check this show manually`,
+        );
+      }
+    } else if (!radarrApiClient && !sonarrApiClient) {
+      if (collection.arrAction !== ServarrAction.UNMONITOR) {
+        this.infoLogger(
+          `Couldn't utilize *arr to find and remove the media with id ${media.plexId}, so media will be removed from the filesystem through Plex. No unmonitor action was taken.`,
+        );
+        await this.plexApi.deleteMediaFromDisk(media.plexId.toString());
+      } else {
+        this.infoLogger(
+          `*arr unmonitor action isn't possible, since *arr is not available. Didn't unmonitor media with id ${media.plexId}.}`,
+        );
       }
     }
 
@@ -475,19 +482,6 @@ export class CollectionWorkerService extends TaskBase {
             break;
         }
       }
-
-      // If *arr not configured, remove media through Plex
-      if (!(plexLibrary.type === 'movie' ? radarrApiClient : sonarrApiClient))
-        if (collection.arrAction !== ServarrAction.UNMONITOR) {
-          await this.plexApi.deleteMediaFromDisk(media.plexId.toString());
-          this.infoLogger(
-            `Couldn't utilize *arr to find and remove the media with id ${media.plexId}, so media was removed from the filesystem through Plex. No unmonitor action was taken.`,
-          );
-        } else {
-          this.infoLogger(
-            `*arr unmonitor action isn't possible, since *arr is not available. Didn't unmonitor media with id ${media.plexId}.}`,
-          );
-        }
     }
   }
 

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -430,6 +430,13 @@ export class RuleConstants {
           mediaType: MediaType.MOVIE,
           type: RuleType.TEXT,
         } as Property,
+        {
+          id: 13,
+          name: 'originalLanguage',
+          humanName: 'Original language',
+          mediaType: MediaType.MOVIE,
+          type: RuleType.TEXT,
+        } as Property,
       ],
     },
     {
@@ -552,6 +559,13 @@ export class RuleConstants {
           id: 14,
           name: 'filePath',
           humanName: 'Base file path',
+          mediaType: MediaType.SHOW,
+          type: RuleType.TEXT,
+        } as Property,
+        {
+          id: 15,
+          name: 'originalLanguage',
+          humanName: 'Original language',
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT,
         } as Property,

--- a/server/src/modules/rules/getter/radarr-getter.service.ts
+++ b/server/src/modules/rules/getter/radarr-getter.service.ts
@@ -56,27 +56,27 @@ export class RadarrGetterService {
             return movieResponse.added ? new Date(movieResponse.added) : null;
           }
           case 'fileDate': {
-            return movieResponse?.movieFile?.dateAdded
+            return movieResponse.movieFile?.dateAdded
               ? new Date(movieResponse.movieFile.dateAdded)
               : null;
           }
           case 'filePath': {
-            return movieResponse?.movieFile?.path
+            return movieResponse.movieFile?.path
               ? movieResponse.movieFile.path
               : null;
           }
           case 'fileQuality': {
-            return movieResponse?.movieFile?.quality?.quality?.resolution
+            return movieResponse.movieFile?.quality?.quality?.resolution
               ? movieResponse.movieFile.quality.quality.resolution
               : null;
           }
           case 'fileAudioChannels': {
-            return movieResponse?.movieFile
+            return movieResponse.movieFile
               ? movieResponse.movieFile.mediaInfo?.audioChannels
               : null;
           }
           case 'runTime': {
-            if (movieResponse?.movieFile?.mediaInfo?.runTime) {
+            if (movieResponse.movieFile?.mediaInfo?.runTime) {
               const hms = movieResponse.movieFile.mediaInfo.runTime;
               const splitted = hms.split(':');
               return +splitted[0] * 60 + +splitted[1];
@@ -84,35 +84,34 @@ export class RadarrGetterService {
             return null;
           }
           case 'monitored': {
-            return movieResponse?.monitored
+            return movieResponse.monitored
               ? movieResponse.monitored
                 ? 1
                 : 0
               : null;
           }
           case 'tags': {
-            const movieTags = movieResponse?.tags;
+            const movieTags = movieResponse.tags;
             return (await radarrApiClient.getTags())
               ?.filter((el) => movieTags.includes(el.id))
               .map((el) => el.label);
           }
           case 'profile': {
-            const movieProfile = movieResponse?.qualityProfileId;
+            const movieProfile = movieResponse.qualityProfileId;
 
             return (await radarrApiClient.getProfiles())?.find(
               (el) => el.id === movieProfile,
             ).name;
           }
           case 'fileSize': {
-            return movieResponse?.sizeOnDisk
+            return movieResponse.sizeOnDisk
               ? Math.round(movieResponse.sizeOnDisk / 1048576)
               : movieResponse.movieFile?.size
                 ? Math.round(movieResponse.movieFile.size / 1048576)
                 : null;
           }
           case 'releaseDate': {
-            return movieResponse?.physicalRelease &&
-              movieResponse?.digitalRelease
+            return movieResponse.physicalRelease && movieResponse.digitalRelease
               ? (await new Date(movieResponse.physicalRelease)) >
                 new Date(movieResponse.digitalRelease)
                 ? new Date(movieResponse.digitalRelease)
@@ -124,8 +123,13 @@ export class RadarrGetterService {
                   : null;
           }
           case 'inCinemas': {
-            return movieResponse?.inCinemas
+            return movieResponse.inCinemas
               ? new Date(movieResponse.inCinemas)
+              : null;
+          }
+          case 'originalLanguage': {
+            return movieResponse.originalLanguage?.name
+              ? movieResponse.originalLanguage.name
               : null;
           }
         }

--- a/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -263,6 +263,11 @@ export class SonarrGetterService {
                   : false;
               }
             }
+            case 'originalLanguage': {
+              return showResponse.originalLanguage?.name
+                ? showResponse.originalLanguage.name
+                : null;
+            }
           }
         } else return null;
       } else {

--- a/server/src/modules/rules/rules.service.ts
+++ b/server/src/modules/rules/rules.service.ts
@@ -1014,7 +1014,9 @@ export class RulesService {
         );
 
         //test first value
-        const first = firstValApplication.props[parsedRule.firstVal[1]];
+        const first = firstValApplication.props.find(
+          (x) => x.id == parsedRule.firstVal[1],
+        );
 
         result = first.cacheReset ? true : result;
 
@@ -1023,7 +1025,9 @@ export class RulesService {
           : undefined;
 
         // test second value
-        const second = secondValApplication?.props[parsedRule.lastVal[1]];
+        const second = secondValApplication?.props.find(
+          (x) => x.id == parsedRule.lastVal[1],
+        );
 
         result = second?.cacheReset ? true : result;
       }

--- a/server/src/modules/rules/rules.service.ts
+++ b/server/src/modules/rules/rules.service.ts
@@ -238,6 +238,8 @@ export class RulesService {
           forceOverseerr: params.forceOverseerr ? params.forceOverseerr : false,
           tautulliWatchedPercentOverride:
             params.tautulliWatchedPercentOverride ?? null,
+          radarrSettingsId: params.radarrSettingsId ?? null,
+          sonarrSettingsId: params.sonarrSettingsId ?? null,
           visibleOnRecommended: params.collection?.visibleOnRecommended,
           visibleOnHome: params.collection?.visibleOnHome,
           deleteAfterDays: +params.collection?.deleteAfterDays,

--- a/server/src/modules/settings/dto's/radarr-setting.dto.ts
+++ b/server/src/modules/settings/dto's/radarr-setting.dto.ts
@@ -8,8 +8,6 @@ export type RadarrSettingDto = {
   url: string;
 
   apiKey: string;
-
-  isDefault: boolean;
 };
 
 export type RadarrSettingRawDto = Omit<RadarrSettingDto, 'id'>;

--- a/server/src/modules/settings/dto's/sonarr-setting.dto.ts
+++ b/server/src/modules/settings/dto's/sonarr-setting.dto.ts
@@ -8,8 +8,6 @@ export type SonarrSettingDto = {
   url: string;
 
   apiKey: string;
-
-  isDefault: boolean;
 };
 
 export type SonarrSettingRawDto = Omit<SonarrSettingDto, 'id'>;

--- a/server/src/modules/settings/entities/radarr_settings.entities.ts
+++ b/server/src/modules/settings/entities/radarr_settings.entities.ts
@@ -15,9 +15,6 @@ export class RadarrSettings {
   @Column({ nullable: true })
   apiKey: string;
 
-  @Column({ default: false })
-  isDefault: boolean;
-
   @OneToMany(() => Collection, (collection) => collection.radarrSettings)
   collections: Collection[];
 }

--- a/server/src/modules/settings/entities/sonarr_settings.entities.ts
+++ b/server/src/modules/settings/entities/sonarr_settings.entities.ts
@@ -15,9 +15,6 @@ export class SonarrSettings {
   @Column({ nullable: true })
   apiKey: string;
 
-  @Column({ default: false })
-  isDefault: boolean;
-
   @OneToMany(() => Collection, (collection) => collection.sonarrSettings)
   collections: Collection[];
 }

--- a/server/src/modules/settings/settings.service.ts
+++ b/server/src/modules/settings/settings.service.ts
@@ -1,7 +1,7 @@
 import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomUUID } from 'crypto';
-import { Not, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { isValidCron } from 'cron-validator';
 import { BasicResponseDto } from '../api/external-api/dto/basic-response.dto';
 import { OverseerrApiService } from '../api/overseerr-api/overseerr-api.service';
@@ -154,25 +154,15 @@ export class SettingsService implements SettingDto {
     try {
       settings.url = settings.url.toLowerCase();
 
-      return this.radarrSettingsRepo.manager.transaction(async (manager) => {
-        if (settings.isDefault) {
-          await manager
-            .withRepository(this.radarrSettingsRepo)
-            .update({ isDefault: true }, { isDefault: false });
-        }
+      const savedSetting = await this.radarrSettingsRepo.save(settings);
 
-        const savedSetting = await manager
-          .withRepository(this.radarrSettingsRepo)
-          .save(settings);
-
-        this.logger.log('Radarr setting added');
-        return {
-          data: savedSetting,
-          status: 'OK',
-          code: 1,
-          message: 'Success',
-        };
-      });
+      this.logger.log('Radarr setting added');
+      return {
+        data: savedSetting,
+        status: 'OK',
+        code: 1,
+        message: 'Success',
+      };
     } catch (e) {
       this.logger.error('Error while adding Radarr setting: ', e);
       return { status: 'NOK', code: 0, message: 'Failure' };
@@ -185,33 +175,16 @@ export class SettingsService implements SettingDto {
     try {
       settings.url = settings.url.toLowerCase();
 
-      const data = await this.radarrSettingsRepo.manager.transaction(
-        async (manager) => {
-          const settingsDb = await manager
-            .withRepository(this.radarrSettingsRepo)
-            .findOne({
-              where: { id: settings.id },
-            });
+      const settingsDb = await this.radarrSettingsRepo.findOne({
+        where: { id: settings.id },
+      });
 
-          const data = {
-            ...settingsDb,
-            ...settings,
-          };
+      const data = {
+        ...settingsDb,
+        ...settings,
+      };
 
-          await manager.withRepository(this.radarrSettingsRepo).save(data);
-
-          if (settings.isDefault) {
-            await manager
-              .withRepository(this.radarrSettingsRepo)
-              .update(
-                { isDefault: true, id: Not(settings.id) },
-                { isDefault: false },
-              );
-          }
-
-          return data;
-        },
-      );
+      await this.radarrSettingsRepo.save(data);
 
       this.servarr.deleteCachedRadarrApiClient(settings.id);
       this.logger.log('Radarr settings updated');
@@ -284,25 +257,15 @@ export class SettingsService implements SettingDto {
     try {
       settings.url = settings.url.toLowerCase();
 
-      return this.sonarrSettingsRepo.manager.transaction(async (manager) => {
-        if (settings.isDefault) {
-          await manager
-            .withRepository(this.sonarrSettingsRepo)
-            .update({ isDefault: true }, { isDefault: false });
-        }
+      const savedSetting = await this.sonarrSettingsRepo.save(settings);
 
-        const savedSetting = await manager
-          .withRepository(this.sonarrSettingsRepo)
-          .save(settings);
-
-        this.logger.log('Sonarr setting added');
-        return {
-          data: savedSetting,
-          status: 'OK',
-          code: 1,
-          message: 'Success',
-        };
-      });
+      this.logger.log('Sonarr setting added');
+      return {
+        data: savedSetting,
+        status: 'OK',
+        code: 1,
+        message: 'Success',
+      };
     } catch (e) {
       this.logger.error('Error while adding Sonarr setting: ', e);
       return { status: 'NOK', code: 0, message: 'Failure' };
@@ -315,33 +278,16 @@ export class SettingsService implements SettingDto {
     try {
       settings.url = settings.url.toLowerCase();
 
-      const data = await this.sonarrSettingsRepo.manager.transaction(
-        async (manager) => {
-          const settingsDb = await manager
-            .withRepository(this.sonarrSettingsRepo)
-            .findOne({
-              where: { id: settings.id },
-            });
+      const settingsDb = await this.sonarrSettingsRepo.findOne({
+        where: { id: settings.id },
+      });
 
-          const data = {
-            ...settingsDb,
-            ...settings,
-          };
+      const data = {
+        ...settingsDb,
+        ...settings,
+      };
 
-          await manager.withRepository(this.sonarrSettingsRepo).save(data);
-
-          if (settings.isDefault) {
-            await manager
-              .withRepository(this.sonarrSettingsRepo)
-              .update(
-                { isDefault: true, id: Not(settings.id) },
-                { isDefault: false },
-              );
-          }
-
-          return data;
-        },
-      );
+      await this.sonarrSettingsRepo.save(data);
 
       this.servarr.deleteCachedSonarrApiClient(settings.id);
 

--- a/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.tsx
+++ b/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.tsx
@@ -9,8 +9,8 @@ interface ArrActionProps {
   type: ArrType
   arrAction?: number
   settingId?: number | null // null for when the user has selected 'None', undefined for when this is a new rule
-  options?: Option[]
-  onUpdate: (value: number, settingId?: number | null) => void
+  options: Option[]
+  onUpdate: (arrAction: number, settingId?: number | null) => void
 }
 
 interface Option {
@@ -25,10 +25,11 @@ const ArrAction = (props: ArrActionProps) => {
     [],
   )
   const [loading, setLoading] = useState<boolean>(true)
-  const action = props.arrAction ? props.arrAction : 0
+  const action = props.arrAction ?? 0
 
   const handleSelectedSettingIdChange = (id?: number | null) => {
-    props.onUpdate(action, id)
+    const actionUpdate = id == null ? 0 : action
+    props.onUpdate(actionUpdate, id)
   }
 
   const handleActionChange = (value: number) => {
@@ -57,22 +58,16 @@ const ArrAction = (props: ArrActionProps) => {
     loadArrSettings(props.type)
   }, [props.type])
 
-  const options: Option[] = props.options
-    ? props.options
-    : [
+  const noneServerSelected = selectedSetting === ''
+
+  const options: Option[] = noneServerSelected
+    ? [
         {
           id: 0,
           name: 'Delete',
         },
-        {
-          id: 1,
-          name: 'Unmonitor and delete files',
-        },
-        {
-          id: 3,
-          name: 'Unmonitor and keep files',
-        },
       ]
+    : props.options
 
   return (
     <div>
@@ -114,7 +109,7 @@ const ArrAction = (props: ArrActionProps) => {
       </div>
       <div className="form-row">
         <label htmlFor={`${props.type}-action`} className="text-label">
-          {props.type} action
+          {noneServerSelected ? 'Plex' : props.type} action
         </label>
         <div className="form-input">
           <div className="form-input-field">

--- a/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -64,12 +64,10 @@ interface ICreateApiObject {
 
 const AddModal = (props: AddModal) => {
   const [selectedLibraryId, setSelectedLibraryId] = useState<string>(
-    props.editData ? props.editData.libraryId.toString() : '1',
+    props.editData ? props.editData.libraryId.toString() : '',
   )
   const [selectedType, setSelectedType] = useState<string>(
-    props.editData && props.editData.type
-      ? props.editData.type.toString()
-      : '1',
+    props.editData?.type ? props.editData.type.toString() : '',
   )
   const [selectedLibrary, setSelectedLibrary] = useState<ILibrary>()
   const [collection, setCollection] = useState<ICollection>()
@@ -81,7 +79,7 @@ const AddModal = (props: AddModal) => {
   const nameRef = useRef<any>()
   const descriptionRef = useRef<any>()
   const libraryRef = useRef<any>()
-  const collectionTypeRef = useRef<any>(EPlexDataType.MOVIES)
+  const collectionTypeRef = useRef<any>()
   const deleteAfterRef = useRef<any>()
   const keepLogsForMonthsRef = useRef<any>()
   const tautulliWatchedPercentOverrideRef = useRef<any>()
@@ -99,12 +97,18 @@ const AddModal = (props: AddModal) => {
     props.editData ? props.editData.useRules : true,
   )
   const [arrOption, setArrOption] = useState<number>()
-  const [radarrSettingsId, setRadarrSettingsId] = useState<number>()
-  const [sonarrSettingsId, setSonarrSettingsId] = useState<number>()
-  const [originalRadarrSettingsId, setOriginalRadarrSettingsId] =
-    useState<number>()
-  const [originalSonarrSettingsId, setOriginalSonarrSettingsId] =
-    useState<number>()
+  const [radarrSettingsId, setRadarrSettingsId] = useState<
+    number | null | undefined
+  >(props.editData ? null : undefined)
+  const [sonarrSettingsId, setSonarrSettingsId] = useState<
+    number | null | undefined
+  >(props.editData ? null : undefined)
+  const [originalRadarrSettingsId, setOriginalRadarrSettingsId] = useState<
+    number | null | undefined
+  >(props.editData ? null : undefined)
+  const [originalSonarrSettingsId, setOriginalSonarrSettingsId] = useState<
+    number | null | undefined
+  >(props.editData ? null : undefined)
   const [showArrServerChangeWarning, setShowArrServerChangeWarning] =
     useState<boolean>(false)
   const [active, setActive] = useState<boolean>(
@@ -128,9 +132,27 @@ const AddModal = (props: AddModal) => {
       (x) => x.id == Application.OVERSEERR,
     ) ?? false
 
-  function setLibraryId(event: { target: { value: string } }) {
-    setSelectedLibraryId(event.target.value)
+  function updateLibraryId(value: string) {
+    setLibraryId(value)
+    setRadarrSettingsId(undefined)
+    setSonarrSettingsId(undefined)
     setArrOption(0)
+  }
+
+  function setLibraryId(value: string) {
+    const lib = LibrariesCtx.libraries.find(
+      (el: ILibrary) => +el.key === +value,
+    )
+
+    if (lib) {
+      setSelectedLibraryId(lib.key)
+      setSelectedLibrary(lib)
+      setSelectedType(
+        lib.type === 'movie'
+          ? EPlexDataType.MOVIES.toString()
+          : EPlexDataType.SHOWS.toString(),
+      )
+    }
   }
 
   function setCollectionType(event: { target: { value: string } }) {
@@ -141,7 +163,7 @@ const AddModal = (props: AddModal) => {
   const handleUpdateArrAction = (
     type: 'Radarr' | 'Sonarr',
     e: number,
-    settingId?: number,
+    settingId?: number | null,
   ) => {
     setArrOption(e)
 
@@ -152,7 +174,6 @@ const AddModal = (props: AddModal) => {
 
       if (
         props.editData &&
-        originalRadarrSettingsId != null &&
         originalRadarrSettingsId != settingId &&
         settingId != radarrSettingsId
       ) {
@@ -165,7 +186,6 @@ const AddModal = (props: AddModal) => {
 
       if (
         props.editData &&
-        originalSonarrSettingsId != null &&
         originalSonarrSettingsId != settingId &&
         settingId != sonarrSettingsId
       ) {
@@ -250,14 +270,6 @@ const AddModal = (props: AddModal) => {
   }
 
   useEffect(() => {
-    const lib = LibrariesCtx.libraries.find(
-      (el: ILibrary) => +el.key === +selectedLibraryId,
-    )
-    setSelectedLibrary(lib)
-    setSelectedType(lib?.type === 'movie' ? '1' : '2')
-  }, [selectedLibraryId])
-
-  useEffect(() => {
     setIsLoading(true)
 
     const load = async () => {
@@ -295,12 +307,13 @@ const AddModal = (props: AddModal) => {
         setListExclusion(collection.listExclusions!)
         setForceOverseerr(collection.forceOverseerr!)
         setArrOption(collection.arrAction)
-        setSelectedType(collection.type ? collection.type.toString() : '1')
+        setSelectedType(collection.type.toString())
         setManualCollection(collection.manualCollection)
-        setRadarrSettingsId(collection.radarrSettingsId)
-        setSonarrSettingsId(collection.sonarrSettingsId)
-        setOriginalRadarrSettingsId(collection.radarrSettingsId)
-        setOriginalSonarrSettingsId(collection.sonarrSettingsId)
+        setRadarrSettingsId(collection.radarrSettingsId ?? null)
+        setSonarrSettingsId(collection.sonarrSettingsId ?? null)
+        setOriginalRadarrSettingsId(collection.radarrSettingsId ?? null)
+        setOriginalSonarrSettingsId(collection.sonarrSettingsId ?? null)
+        setLibraryId(collection.libraryId.toString())
       }
 
       setIsLoading(false)
@@ -329,6 +342,7 @@ const AddModal = (props: AddModal) => {
       nameRef.current.value &&
       libraryRef.current.value &&
       deleteAfterRef.current.value &&
+      (radarrSettingsId !== undefined || sonarrSettingsId !== undefined) &&
       ((useRules && rules.length > 0) || !useRules)
     ) {
       setFormIncomplete(false)
@@ -347,8 +361,8 @@ const AddModal = (props: AddModal) => {
           tautulliWatchedPercentOverrideRef.current.value != ''
             ? +tautulliWatchedPercentOverrideRef.current.value
             : undefined,
-        radarrSettingsId: radarrSettingsId,
-        sonarrSettingsId: sonarrSettingsId,
+        radarrSettingsId: radarrSettingsId ?? undefined,
+        sonarrSettingsId: sonarrSettingsId ?? undefined,
         collection: {
           visibleOnRecommended: showRecommended,
           visibleOnHome: showHome,
@@ -476,9 +490,12 @@ const AddModal = (props: AddModal) => {
                     name="library"
                     id="library"
                     value={selectedLibraryId}
-                    onChange={setLibraryId}
+                    onChange={(e) => updateLibraryId(e.target.value)}
                     ref={libraryRef}
                   >
+                    {selectedLibraryId === '' && (
+                      <option value="" disabled></option>
+                    )}
                     {LibrariesCtx.libraries.map((data: ILibrary) => {
                       return (
                         <option key={data.key} value={data.key}>
@@ -490,7 +507,7 @@ const AddModal = (props: AddModal) => {
                 </div>
               </div>
             </div>
-            {selectedLibrary && selectedLibrary!.type === 'movie' ? (
+            {selectedLibrary && selectedLibrary!.type === 'movie' && (
               <ArrAction
                 type="Radarr"
                 arrAction={arrOption}
@@ -499,7 +516,9 @@ const AddModal = (props: AddModal) => {
                   handleUpdateArrAction('Radarr', e, settingId)
                 }}
               />
-            ) : (
+            )}
+
+            {selectedLibrary && selectedLibrary!.type !== 'movie' && (
               <>
                 <div className="form-row">
                   <label htmlFor="type" className="text-label">

--- a/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -162,35 +162,35 @@ const AddModal = (props: AddModal) => {
 
   const handleUpdateArrAction = (
     type: 'Radarr' | 'Sonarr',
-    e: number,
+    arrAction: number,
     settingId?: number | null,
   ) => {
-    setArrOption(e)
+    setArrOption(arrAction)
 
     if (type === 'Radarr') {
-      setSonarrSettingsId(undefined)
-      setOriginalSonarrSettingsId(undefined)
-      setRadarrSettingsId(settingId)
-
       if (
         props.editData &&
+        originalRadarrSettingsId !== undefined &&
         originalRadarrSettingsId != settingId &&
         settingId != radarrSettingsId
       ) {
         setShowArrServerChangeWarning(true)
       }
-    } else if (type === 'Sonarr') {
-      setRadarrSettingsId(undefined)
-      setOriginalRadarrSettingsId(undefined)
-      setSonarrSettingsId(settingId)
 
+      setSonarrSettingsId(undefined)
+      setRadarrSettingsId(settingId)
+    } else if (type === 'Sonarr') {
       if (
         props.editData &&
+        originalSonarrSettingsId !== undefined &&
         originalSonarrSettingsId != settingId &&
         settingId != sonarrSettingsId
       ) {
         setShowArrServerChangeWarning(true)
       }
+
+      setRadarrSettingsId(undefined)
+      setSonarrSettingsId(settingId)
     }
   }
 
@@ -512,9 +512,23 @@ const AddModal = (props: AddModal) => {
                 type="Radarr"
                 arrAction={arrOption}
                 settingId={radarrSettingsId}
-                onUpdate={(e: number, settingId) => {
-                  handleUpdateArrAction('Radarr', e, settingId)
+                onUpdate={(arrAction: number, settingId) => {
+                  handleUpdateArrAction('Radarr', arrAction, settingId)
                 }}
+                options={[
+                  {
+                    id: 0,
+                    name: 'Delete',
+                  },
+                  {
+                    id: 1,
+                    name: 'Unmonitor and delete files',
+                  },
+                  {
+                    id: 3,
+                    name: 'Unmonitor and keep files',
+                  },
+                ]}
               />
             )}
 

--- a/ui/src/components/Settings/Radarr/SettingsModal/index.tsx
+++ b/ui/src/components/Settings/Radarr/SettingsModal/index.tsx
@@ -47,7 +47,6 @@ interface RadarrSettingSaveRequest {
   url: string
   apiKey: string
   serverName: string
-  isDefault: boolean
 }
 
 const RadarrSettingsModal = (props: IRadarrSettingsModal) => {
@@ -66,14 +65,12 @@ const RadarrSettingsModal = (props: IRadarrSettingsModal) => {
     : ''
   const initialApiKey = props.settings?.apiKey ?? ''
   const initialServerName = props.settings?.serverName ?? ''
-  const initialIsDefault = props.settings?.isDefault ?? false
 
   const [hostname, setHostname] = useState<string>(initialHostname)
   const [baseUrl, setBaseUrl] = useState<string>(initialBaseUrl)
   const [port, setPort] = useState<string>(initialPort)
   const [apiKey, setApiKey] = useState<string>(initialApiKey)
   const [serverName, setServerName] = useState<string>(initialServerName)
-  const [isDefault, setIsDefault] = useState<boolean>(initialIsDefault)
 
   const [error, setError] = useState<boolean>()
   const [testedSettings, setTestedSettings] = useState(
@@ -138,7 +135,6 @@ const RadarrSettingsModal = (props: IRadarrSettingsModal) => {
         url: `${radarrUrl}${baseUrl ? `/${baseUrl}` : ''}`,
         apiKey: apiKey,
         serverName: serverName,
-        isDefault: isDefault,
         ...(props.settings?.id && { id: props.settings?.id }),
       }
 
@@ -229,23 +225,6 @@ const RadarrSettingsModal = (props: IRadarrSettingsModal) => {
           <Alert type="error" title="Failed to connect to Radarr" />
         )
       ) : undefined}
-
-      <div className="form-row">
-        <label htmlFor="isDefault" className="text-label">
-          Default Server
-        </label>
-        <div className="form-input">
-          <div className="form-input-field">
-            <input
-              type="checkbox"
-              name="isDefault"
-              id="isDefault"
-              checked={isDefault}
-              onChange={(e) => setIsDefault(e.target.checked)}
-            />
-          </div>
-        </div>
-      </div>
 
       <div className="form-row">
         <label htmlFor="serverName" className="text-label">

--- a/ui/src/components/Settings/Radarr/index.tsx
+++ b/ui/src/components/Settings/Radarr/index.tsx
@@ -32,7 +32,6 @@ export interface IRadarrSetting {
   serverName: string
   url: string
   apiKey: string
-  isDefault: boolean
 }
 
 const RadarrSettings = () => {
@@ -52,14 +51,6 @@ const RadarrSettings = () => {
       newSettings[index] = setting
     } else {
       newSettings.push(setting)
-    }
-
-    if (setting.isDefault) {
-      newSettings.forEach((s) => {
-        if (s.id !== setting.id) {
-          s.isDefault = false
-        }
-      })
     }
 
     setSettings(newSettings)
@@ -121,17 +112,9 @@ const RadarrSettings = () => {
               key={setting.id}
               className="h-full rounded-xl bg-zinc-800 p-4 text-zinc-400 shadow ring-1 ring-zinc-700"
             >
-              <div className="mb-2 flex items-center gap-x-3">
-                <div className="text-base font-medium text-white sm:text-lg">
-                  {setting.serverName}
-                </div>
-                {setting.isDefault && (
-                  <div className="rounded bg-amber-600 px-2 py-0.5 text-xs text-zinc-200 shadow-md">
-                    Default
-                  </div>
-                )}
+              <div className="mb-2 flex items-center gap-x-3 text-base font-medium text-white sm:text-lg">
+                {setting.serverName}
               </div>
-
               <p className="mb-4 space-x-2 truncate text-gray-300">
                 <span className="font-semibold">Address</span>
                 <a href={setting.url} className="hover:underline">

--- a/ui/src/components/Settings/Sonarr/SettingsModal/index.tsx
+++ b/ui/src/components/Settings/Sonarr/SettingsModal/index.tsx
@@ -47,7 +47,6 @@ interface SonarrSettingSaveRequest {
   url: string
   apiKey: string
   serverName: string
-  isDefault: boolean
 }
 
 const SonarrSettingsModal = (props: ISonarrSettingsModal) => {
@@ -66,14 +65,12 @@ const SonarrSettingsModal = (props: ISonarrSettingsModal) => {
     : ''
   const initialApiKey = props.settings?.apiKey ?? ''
   const initialServerName = props.settings?.serverName ?? ''
-  const initialIsDefault = props.settings?.isDefault ?? false
 
   const [hostname, setHostname] = useState<string>(initialHostname)
   const [baseUrl, setBaseUrl] = useState<string>(initialBaseUrl)
   const [port, setPort] = useState<string>(initialPort)
   const [apiKey, setApiKey] = useState<string>(initialApiKey)
   const [serverName, setServerName] = useState<string>(initialServerName)
-  const [isDefault, setIsDefault] = useState<boolean>(initialIsDefault)
 
   const [error, setError] = useState<boolean>()
   const [testedSettings, setTestedSettings] = useState(
@@ -138,7 +135,6 @@ const SonarrSettingsModal = (props: ISonarrSettingsModal) => {
         url: `${sonarrUrl}${baseUrl ? `/${baseUrl}` : ''}`,
         apiKey: apiKey,
         serverName: serverName,
-        isDefault: isDefault,
         ...(props.settings?.id && { id: props.settings?.id }),
       }
 
@@ -229,23 +225,6 @@ const SonarrSettingsModal = (props: ISonarrSettingsModal) => {
           <Alert type="error" title="Failed to connect to Sonarr" />
         )
       ) : undefined}
-
-      <div className="form-row">
-        <label htmlFor="isDefault" className="text-label">
-          Default Server
-        </label>
-        <div className="form-input">
-          <div className="form-input-field">
-            <input
-              type="checkbox"
-              name="isDefault"
-              id="isDefault"
-              checked={isDefault}
-              onChange={(e) => setIsDefault(e.target.checked)}
-            />
-          </div>
-        </div>
-      </div>
 
       <div className="form-row">
         <label htmlFor="serverName" className="text-label">

--- a/ui/src/components/Settings/Sonarr/index.tsx
+++ b/ui/src/components/Settings/Sonarr/index.tsx
@@ -32,7 +32,6 @@ export interface ISonarrSetting {
   serverName: string
   url: string
   apiKey: string
-  isDefault: boolean
 }
 
 const SonarrSettings = () => {
@@ -52,14 +51,6 @@ const SonarrSettings = () => {
       newSettings[index] = setting
     } else {
       newSettings.push(setting)
-    }
-
-    if (setting.isDefault) {
-      newSettings.forEach((s) => {
-        if (s.id !== setting.id) {
-          s.isDefault = false
-        }
-      })
     }
 
     setSettings(newSettings)
@@ -121,17 +112,9 @@ const SonarrSettings = () => {
               key={setting.id}
               className="h-full rounded-xl bg-zinc-800 p-4 text-zinc-400 shadow ring-1 ring-zinc-700"
             >
-              <div className="mb-2 flex items-center gap-x-3">
-                <div className="text-base font-medium text-white sm:text-lg">
-                  {setting.serverName}
-                </div>
-                {setting.isDefault && (
-                  <div className="rounded bg-amber-600 px-2 py-0.5 text-xs text-zinc-200 shadow-md">
-                    Default
-                  </div>
-                )}
+              <div className="mb-2 flex items-center gap-x-3 text-base font-medium text-white sm:text-lg">
+                {setting.serverName}
               </div>
-
               <p className="mb-4 space-x-2 truncate text-gray-300">
                 <span className="font-semibold">Address</span>
                 <a href={setting.url} className="hover:underline">


### PR DESCRIPTION
For feature request: https://features.maintainerr.info/posts/52/allow-to-filter-based-on-the-original-language-value-in-sonarr

I've fixed the Radarr & Sonarr server selection not persisting on initial rule creation. I've also fixed an exception/logic error when checking the cacheReset flag.