### PR TITLE
fix: changed all docs URLs to match new docs URL generations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Docker images for amd64 & arm64 are available under [jorenn92/maintainerr](https
 Data is saved within the container under /opt/data, it is recommended to tie a persistent volume to this location in your docker command/compose file.
 Make sure this directory is read/writeable by the user specified in the 'user' instruction. If no 'user' instruction is configured, the volume should be accessible by UID:GID 1000:1000.
 
-For more information, visit the [installation guide](https://docs.maintainerr.info/Installation).
+For more information, visit the [installation guide](https://docs.maintainerr.info/Installation.html).
 
 Docker run:
 

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -17,7 +17,7 @@ const nextConfig = {
     return [
       {
         source: '/docs',
-        destination: 'https://docs.maintainerr.info/Introduction/',
+        destination: 'https://docs.maintainerr.info/Introduction.html',
         permanent: true,
       },
     ]

--- a/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -401,7 +401,7 @@ const AddModal = (props: AddModal) => {
           <div className="ml-auto">
             <Link
               legacyBehavior
-              href={`https://docs.maintainerr.info/Rules`}
+              href={`https://docs.maintainerr.info/Rules.html`}
               passHref={true}
             >
               <a target="_blank" rel="noopener noreferrer">

--- a/ui/src/components/Settings/Overseerr/index.tsx
+++ b/ui/src/components/Settings/Overseerr/index.tsx
@@ -196,7 +196,7 @@ const OverseerrSettings = () => {
           <div className="actions mt-5 w-full">
             <div className="flex w-full flex-wrap sm:flex-nowrap">
               <span className="m-auto rounded-md shadow-sm sm:ml-3 sm:mr-auto">
-                <DocsButton page="Configuration" />
+                <DocsButton page="Configuration.html#overseerr" />
               </span>
               <div className="m-auto mt-3 flex xs:mt-0 sm:m-0 sm:justify-end">
                 <TestButton

--- a/ui/src/components/Settings/Plex/index.tsx
+++ b/ui/src/components/Settings/Plex/index.tsx
@@ -107,7 +107,9 @@ const PlexSettings = () => {
         plex_auth_token?: string
       } = {
         plex_hostname: sslRef.current?.checked
-          ? `https://${hostnameRef.current.value.replace('http://', '').replace('https://', '')}`
+          ? `https://${hostnameRef.current.value
+              .replace('http://', '')
+              .replace('https://', '')}`
           : hostnameRef.current.value
               .replace('http://', '')
               .replace('https://', ''),
@@ -502,7 +504,7 @@ const PlexSettings = () => {
           <div className="actions mt-5 w-full">
             <div className="flex w-full flex-wrap sm:flex-nowrap">
               <span className="m-auto rounded-md shadow-sm sm:ml-3 sm:mr-auto">
-                <DocsButton page="Configuration" />
+                <DocsButton page="Configuration.html#plex" />
               </span>
               <div className="m-auto mt-3 flex xs:mt-0 sm:m-0 sm:justify-end">
                 <TestButton onClick={appTest} testUrl="/settings/test/plex" />

--- a/ui/src/components/Settings/Radarr/SettingsModal/index.tsx
+++ b/ui/src/components/Settings/Radarr/SettingsModal/index.tsx
@@ -336,7 +336,7 @@ const RadarrSettingsModal = (props: IRadarrSettingsModal) => {
       <div className="actions mt-5 w-full">
         <div className="flex w-full flex-wrap sm:flex-nowrap">
           <span className="m-auto rounded-md shadow-sm sm:ml-3 sm:mr-auto">
-            <DocsButton page="Configuration" />
+            <DocsButton page="Configuration.html#radarr" />
           </span>
         </div>
       </div>

--- a/ui/src/components/Settings/Sonarr/SettingsModal/index.tsx
+++ b/ui/src/components/Settings/Sonarr/SettingsModal/index.tsx
@@ -336,7 +336,7 @@ const SonarrSettingsModal = (props: ISonarrSettingsModal) => {
       <div className="actions mt-5 w-full">
         <div className="flex w-full flex-wrap sm:flex-nowrap">
           <span className="m-auto rounded-md shadow-sm sm:ml-3 sm:mr-auto">
-            <DocsButton page="Configuration" />
+            <DocsButton page="Configuration.html#sonarr" />
           </span>
         </div>
       </div>

--- a/ui/src/components/Settings/Tautulli/index.tsx
+++ b/ui/src/components/Settings/Tautulli/index.tsx
@@ -199,7 +199,7 @@ const TautulliSettings = () => {
           <div className="actions mt-5 w-full">
             <div className="flex w-full flex-wrap sm:flex-nowrap">
               <span className="m-auto rounded-md shadow-sm sm:ml-3 sm:mr-auto">
-                <DocsButton page="Configuration" />
+                <DocsButton page="Configuration.html#tautulli" />
               </span>
               <div className="m-auto mt-3 flex xs:mt-0 sm:m-0 sm:justify-end">
                 <TestButton


### PR DESCRIPTION
With the changes to the docs URL generation, it no longer creates URLs from the directory structure. This started causing problems with redirect errors in the docs. Now all docs links, besides the main URL `docs.maintainerr.info` end with `.html`

All URLs in the project have been corrected to point at the right URL.