### PR TITLE
fix: Container startup failing for some

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -2,6 +2,6 @@
 
 BASE_PATH_REPLACE="${BASE_PATH:-}"
 
-find /opt/app/ui -type f -exec sed -i "s,/__PATH_PREFIX__,$BASE_PATH_REPLACE,g" '{}' \;
+find /opt/app/ui -type f -not -path '*/node_modules/*' -print0 | xargs -0 sed -i "s,/__PATH_PREFIX__,$BASE_PATH_REPLACE,g"
 
 /usr/bin/supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
For whatever reason the find exec command is hanging for somebody with a Synology DS920+. We tried a bunch of different ways and settled on xargs instead of exec. I've also ignored the node_modules folder to speed up processing.

Discord thread: https://discord.com/channels/1152219249549512724/1318539096813076563