### PR TITLE
fix: Community rules & incorrect out of date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY --from=builder --chmod=777 --chown=node:node /app/ui/public ./ui/public
 
 # Copy standalone server
 COPY --from=builder --chmod=777 --chown=node:node /app/server/dist ./server
+COPY --from=builder --chmod=777 --chown=node:node /app/server/package.json ./server/package.json
 COPY --from=builder --chmod=777 --chown=node:node /app/server/node_modules ./server/node_modules
 
 COPY docker/supervisord.conf /etc/supervisord.conf

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -4,7 +4,7 @@ logfile=/dev/null
 pidfile=/dev/null
 
 [program:server]
-command=node /opt/app/server/main.js
+command=npm run --prefix /opt/app/server start:release
 autorestart=true
 startretries=100
 stdout_logfile=/dev/fd/1

--- a/package.json
+++ b/package.json
@@ -46,10 +46,18 @@
       ],
       "@semantic-release/npm",
       [
+        "@semantic-release/exec",
+        {
+          "prepareCmd": "yarn --cwd server version ${nextRelease.version} && yarn --cwd ui version ${nextRelease.version}"
+        }
+      ],
+      [
         "@semantic-release/git",
         {
           "assets": [
             "package.json",
+            "server/package.json",
+            "ui/package.json",
             "CHANGELOG.md"
           ],
           "message": "chore(release): ${nextRelease.version}"

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@maintainerr/server",
+  "version": "2.3.1",
   "private": true,
   "exports": {
     "./*": "./src/*.ts"
@@ -11,6 +12,7 @@
     "dev": "nest start --watch",
     "build": "nest build",
     "start": "node dist/main",
+    "start:release": "node main",
     "lint": "eslint \"{src,test}/**/*.ts\" --fix",
     "format": "prettier --write --ignore-path .gitignore .",
     "format:check": "prettier --check --ignore-path .gitignore .",

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@maintainerr/ui",
+  "version": "2.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Both bugs were caused by not being able to detect the current version. I've updated the semantic-release config to stamp the workspace package.json's with the release version and have updated how we start the server so that npm_package_version gets populated.