### PR TITLE
fix: Do not reset collection on *arr server change

### DIFF
--- a/server/src/modules/rules/rules.service.ts
+++ b/server/src/modules/rules/rules.service.ts
@@ -316,16 +316,14 @@ export class RulesService {
           group.collectionId,
         );
 
-        // if datatype, manual collection settings or *arr server changed then remove the collection media and specific exclusions. The Plex collection will be removed later by updateCollection()
+        // if datatype or manual collection settings changed then remove the collection media and specific exclusions. The Plex collection will be removed later by updateCollection()
         if (
           group.dataType !== params.dataType ||
           params.collection.manualCollection !==
             dbCollection.manualCollection ||
           params.collection.manualCollectionName !==
             dbCollection.manualCollectionName ||
-          params.libraryId !== dbCollection.libraryId ||
-          params.radarrSettingsId !== dbCollection.radarrSettingsId ||
-          params.sonarrSettingsId !== dbCollection.sonarrSettingsId
+          params.libraryId !== dbCollection.libraryId
         ) {
           this.logger.log(
             `A crucial setting of Rulegroup '${params.name}' was changed. Removed all media & specific exclusions`,

--- a/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -30,7 +30,6 @@ import CachedImage from '../../../Common/CachedImage'
 import YamlImporterModal from '../../../Common/YamlImporterModal'
 import { CloudDownloadIcon } from '@heroicons/react/outline'
 import { useToasts } from 'react-toast-notifications'
-import Modal from '../../../Common/Modal'
 
 interface AddModal {
   editData?: IRuleGroup
@@ -103,14 +102,6 @@ const AddModal = (props: AddModal) => {
   const [sonarrSettingsId, setSonarrSettingsId] = useState<
     number | null | undefined
   >(props.editData ? null : undefined)
-  const [originalRadarrSettingsId, setOriginalRadarrSettingsId] = useState<
-    number | null | undefined
-  >(props.editData ? null : undefined)
-  const [originalSonarrSettingsId, setOriginalSonarrSettingsId] = useState<
-    number | null | undefined
-  >(props.editData ? null : undefined)
-  const [showArrServerChangeWarning, setShowArrServerChangeWarning] =
-    useState<boolean>(false)
   const [active, setActive] = useState<boolean>(
     props.editData ? props.editData.isActive : true,
   )
@@ -176,27 +167,9 @@ const AddModal = (props: AddModal) => {
     setArrOption(arrAction)
 
     if (type === 'Radarr') {
-      if (
-        props.editData &&
-        originalRadarrSettingsId !== undefined &&
-        originalRadarrSettingsId != settingId &&
-        settingId != radarrSettingsId
-      ) {
-        setShowArrServerChangeWarning(true)
-      }
-
       setSonarrSettingsId(undefined)
       setRadarrSettingsId(settingId)
     } else if (type === 'Sonarr') {
-      if (
-        props.editData &&
-        originalSonarrSettingsId !== undefined &&
-        originalSonarrSettingsId != settingId &&
-        settingId != sonarrSettingsId
-      ) {
-        setShowArrServerChangeWarning(true)
-      }
-
       setRadarrSettingsId(undefined)
       setSonarrSettingsId(settingId)
     }
@@ -319,8 +292,6 @@ const AddModal = (props: AddModal) => {
         setManualCollection(collection.manualCollection)
         setRadarrSettingsId(collection.radarrSettingsId ?? null)
         setSonarrSettingsId(collection.sonarrSettingsId ?? null)
-        setOriginalRadarrSettingsId(collection.radarrSettingsId ?? null)
-        setOriginalSonarrSettingsId(collection.sonarrSettingsId ?? null)
         setLibraryId(collection.libraryId.toString())
       }
 
@@ -1010,18 +981,6 @@ const AddModal = (props: AddModal) => {
           </form>
         </div>
       </div>
-      {showArrServerChangeWarning ? (
-        <Modal
-          title="Warning"
-          size="sm"
-          onOk={() => setShowArrServerChangeWarning(false)}
-        >
-          <p>
-            Changing server will result in all collection media and specific
-            exclusions being removed.
-          </p>
-        </Modal>
-      ) : undefined}
     </>
   )
 }


### PR DESCRIPTION
Not sure what I was thinking when I added this in. It doesn't make any sense to reset the collection when changing the *arr server, it's similar to changing rule logic which does not trigger a collection reset so why should this.