### PR TITLE
feat: Add season number filter

### DIFF
--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -584,6 +584,14 @@ export class RuleConstants {
           type: RuleType.BOOL,
           showType: [EPlexDataType.SEASONS],
         },
+        {
+          id: 18,
+          name: 'seasonNumber',
+          humanName: 'Season number',
+          mediaType: MediaType.SHOW,
+          type: RuleType.NUMBER,
+          showType: [EPlexDataType.EPISODES, EPlexDataType.SEASONS],
+        },
       ],
     },
     {

--- a/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -294,6 +294,9 @@ export class SonarrGetterService {
 
               return episodes.some((el) => el.finaleType === 'series');
             }
+            case 'seasonNumber': {
+              return season.seasonNumber;
+            }
           }
         } else return null;
       } else {


### PR DESCRIPTION
Adds season number as a filter for Sonarr, as requested in https://features.maintainerr.info/posts/30/selective-season-deletion-for-plex

Dependent on https://github.com/jorenn92/Maintainerr/pull/1471 merging first. Will switch the base branch afterwards.