### PR TITLE
fix: *arr server not persisting on initial save

### DIFF
--- a/server/src/modules/collections/collections.service.ts
+++ b/server/src/modules/collections/collections.service.ts
@@ -941,6 +941,8 @@ export class CollectionsService {
                   collection.manualCollectionName !== undefined
                     ? collection.manualCollectionName
                     : '',
+                sonarrSettingsId: collection.sonarrSettingsId,
+                radarrSettingsId: collection.radarrSettingsId,
               },
             ])
             .execute()


### PR DESCRIPTION
The selected Sonarr/Radarr server was not being saved when creating a new rule.