### PR TITLE
fix: update optional page route param to new syntax

### DIFF
--- a/.github/workflows/dependabot_merge.yml
+++ b/.github/workflows/dependabot_merge.yml
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ contains(github.event.pull_request.title, 'bump')}} && (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor')
+        if: ${{ contains(github.event.pull_request.title, 'bump') && (steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor') }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/server/src/modules/api/plex-api/plex-api.controller.ts
+++ b/server/src/modules/api/plex-api/plex-api.controller.ts
@@ -33,7 +33,7 @@ export class PlexApiController {
   // syncLibraries() {
   //   return this.plexApiService.syncLibraries();
   // }
-  @Get('library/:id/content/:page?')
+  @Get('library/:id/content{/:page}')
   getLibraryContent(
     @Param('id') id: string,
     @Param('page', new ParseIntPipe()) page: number,


### PR DESCRIPTION
A fresh clone of the repo + `yarn && yarn dev` results in the following error, as `path-to-regexp` is locked to v8.2.0 in `yarn.lock`:

![image](https://github.com/user-attachments/assets/a6c91355-7381-4559-bb1f-3c8da13b2cf3)

This PR simply fixes the route param to use the new optional syntax.