### PR TITLE
docs url changes again to support docs versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Docker images for amd64 & arm64 are available under [jorenn92/maintainerr](https
 Data is saved within the container under /opt/data, it is recommended to tie a persistent volume to this location in your docker command/compose file.
 Make sure this directory is read/writeable by the user specified in the 'user' instruction. If no 'user' instruction is configured, the volume should be accessible by UID:GID 1000:1000.
 
-For more information, visit the [installation guide](https://docs.maintainerr.info/Installation).
+For more information, visit the [installation guide](https://docs.maintainerr.info/latest/Installation).
 
 Docker run:
 

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -17,7 +17,7 @@ const nextConfig = {
     return [
       {
         source: '/docs',
-        destination: 'https://docs.maintainerr.info/Introduction',
+        destination: 'https://docs.maintainerr.info/latest/Introduction',
         permanent: true,
       },
     ]

--- a/ui/src/components/Common/DocsButton/index.tsx
+++ b/ui/src/components/Common/DocsButton/index.tsx
@@ -12,7 +12,7 @@ const DocsButton = (props: IDocsButton) => {
     <span className="inline-flex h-full w-full">
       <Link
         legacyBehavior
-        href={`https://docs.maintainerr.info/${props.page ? props.page : ''}`}
+        href={`https://docs.maintainerr.info/latest/${props.page ? props.page : ''}`}
         passHref={true}
       >
         <a target="_blank" rel="noopener noreferrer">

--- a/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -400,7 +400,7 @@ const AddModal = (props: AddModal) => {
           <div className="ml-auto">
             <Link
               legacyBehavior
-              href={`https://docs.maintainerr.info/Rules`}
+              href={`https://docs.maintainerr.info/latest/Rules`}
               passHref={true}
             >
               <a target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
The versioning for mkdocs creates separate folders inside the gh-pages branch. So that you can switch between different versions. You have to set a default alias that auto-redirects `docs.maintainerr.info/latest` the main URL (`docs.maintainerr.info`). However, this only happens for the base domain. The others still need the `/latest` endpoint. 