### PR TITLE
feat: allow comparing list sizes against a number

### DIFF
--- a/server/src/modules/rules/constants/constants.service.ts
+++ b/server/src/modules/rules/constants/constants.service.ts
@@ -84,6 +84,14 @@ export class RuleConstanstService {
         ruleType = RuleType.BOOL;
         value = customValue.value == '1' ? 'true' : 'false';
         break;
+      case 4:
+        ruleType = RuleType.NUMBER_LIST;
+        value = customValue.value;
+        break;
+      case 5:
+        ruleType = RuleType.TEXT_LIST;
+        value = customValue.value;
+        break;
     }
 
     return { type: ruleType.humanName, value: value };
@@ -101,12 +109,20 @@ export class RuleConstanstService {
         ruleType = RuleType.NUMBER;
         value = identifier.value.toString();
         break;
+      case 'NUMBER_LIST':
+        ruleType = RuleType.NUMBER_LIST;
+        value = identifier.value.toString();
+        break;
       case 'DATE':
         ruleType = RuleType.DATE;
         value = identifier.value.toString();
         break;
       case 'TEXT':
         ruleType = RuleType.TEXT;
+        value = identifier.value.toString();
+        break;
+      case 'TEXT_LIST':
+        ruleType = RuleType.TEXT_LIST;
         value = identifier.value.toString();
         break;
       case 'BOOLEAN':

--- a/server/src/modules/rules/constants/constants.service.ts
+++ b/server/src/modules/rules/constants/constants.service.ts
@@ -85,10 +85,6 @@ export class RuleConstanstService {
         value = customValue.value == '1' ? 'true' : 'false';
         break;
       case 4:
-        ruleType = RuleType.NUMBER_LIST;
-        value = +customValue.value;
-        break;
-      case 5:
         ruleType = RuleType.TEXT_LIST;
         value = customValue.value;
         break;
@@ -107,10 +103,6 @@ export class RuleConstanstService {
     switch (identifier.type.toUpperCase()) {
       case 'NUMBER':
         ruleType = RuleType.NUMBER;
-        value = identifier.value.toString();
-        break;
-      case 'NUMBER_LIST':
-        ruleType = RuleType.NUMBER_LIST;
         value = identifier.value.toString();
         break;
       case 'DATE':

--- a/server/src/modules/rules/constants/constants.service.ts
+++ b/server/src/modules/rules/constants/constants.service.ts
@@ -86,7 +86,7 @@ export class RuleConstanstService {
         break;
       case 4:
         ruleType = RuleType.NUMBER_LIST;
-        value = customValue.value;
+        value = +customValue.value;
         break;
       case 5:
         ruleType = RuleType.TEXT_LIST;

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -84,24 +84,8 @@ export class RuleType {
     [RulePossibility.EQUALS, RulePossibility.NOT_EQUALS],
     'boolean',
   );
-  static readonly NUMBER_LIST = new RuleType(
-    '4',
-    [
-      RulePossibility.EQUALS,
-      RulePossibility.NOT_EQUALS,
-      RulePossibility.CONTAINS,
-      RulePossibility.NOT_CONTAINS,
-      RulePossibility.CONTAINS_PARTIAL,
-      RulePossibility.NOT_CONTAINS_PARTIAL,
-      RulePossibility.COUNT_EQUALS,
-      RulePossibility.COUNT_NOT_EQUALS,
-      RulePossibility.COUNT_BIGGER,
-      RulePossibility.COUNT_SMALLER,
-    ],
-    'number list',
-  );
   static readonly TEXT_LIST = new RuleType(
-    '5',
+    '4',
     [
       RulePossibility.EQUALS,
       RulePossibility.NOT_EQUALS,

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -469,7 +469,7 @@ export class RuleConstants {
           mediaType: MediaType.SHOW,
           showType: [EPlexDataType.SEASONS, EPlexDataType.EPISODES],
           cacheReset: true,
-          type: RuleType.TEXT,
+          type: RuleType.TEXT_LIST,
         },
         {
           id: 42,
@@ -477,7 +477,7 @@ export class RuleConstants {
           humanName:
             '[list] Collections media is present in (titles) (incl. smart collections)',
           mediaType: MediaType.BOTH,
-          type: RuleType.TEXT,
+          type: RuleType.TEXT_LIST,
           cacheReset: true,
         },
       ],

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -563,9 +563,9 @@ export class RuleConstants {
         {
           id: 9,
           name: 'fileQuality',
-          humanName: '[list] File - quality (2160, 1080,..)',
+          humanName: 'File - quality (2160, 1080,..)',
           mediaType: MediaType.MOVIE,
-          type: RuleType.NUMBER_LIST,
+          type: RuleType.NUMBER,
         },
         {
           id: 10,

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -514,7 +514,7 @@ export class RuleConstants {
         {
           id: 2,
           name: 'tags',
-          humanName: '[list] Tags (Text if 1, otherwise list)',
+          humanName: '[list] Tags',
           mediaType: MediaType.MOVIE,
           type: RuleType.TEXT_LIST, // return text[]
         },

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -170,7 +170,7 @@ export class RuleConstants {
           name: 'seenBy',
           humanName: '[list] Viewed by (username)',
           mediaType: MediaType.MOVIE,
-          type: RuleType.TEXT, // returns usernames []
+          type: RuleType.TEXT_LIST, // returns usernames []
         },
         {
           id: 2,
@@ -191,7 +191,7 @@ export class RuleConstants {
           name: 'people',
           humanName: '[list] People involved',
           mediaType: MediaType.BOTH,
-          type: RuleType.TEXT, // return text[]
+          type: RuleType.TEXT_LIST, // return text[]
         },
         {
           id: 5,
@@ -220,7 +220,7 @@ export class RuleConstants {
           name: 'fileVideoResolution',
           humanName: '[list] Media file resolution (4k, 1080,..)',
           mediaType: MediaType.MOVIE,
-          type: RuleType.TEXT,
+          type: RuleType.TEXT_LIST,
         },
         {
           id: 9,
@@ -241,14 +241,14 @@ export class RuleConstants {
           name: 'genre',
           humanName: '[list] List of genres (Action, Adventure,..)',
           mediaType: MediaType.BOTH,
-          type: RuleType.TEXT, // return text[]
+          type: RuleType.TEXT_LIST, // return text[]
         },
         {
           id: 12,
           name: 'sw_allEpisodesSeenBy',
           humanName: '[list] Users that saw all available episodes',
           mediaType: MediaType.SHOW,
-          type: RuleType.TEXT, // return usernames []
+          type: RuleType.TEXT_LIST, // return usernames []
           showType: [EPlexDataType.SHOWS, EPlexDataType.SEASONS],
         },
         {
@@ -295,7 +295,7 @@ export class RuleConstants {
           name: 'sw_watchers',
           humanName: '[list] Users that watch the show/season/episode',
           mediaType: MediaType.SHOW,
-          type: RuleType.TEXT, // return usernames []
+          type: RuleType.TEXT_LIST, // return usernames []
           showType: [
             EPlexDataType.SHOWS,
             EPlexDataType.SEASONS,
@@ -307,7 +307,7 @@ export class RuleConstants {
           name: 'collection_names',
           humanName: '[list] Collections media is present in (titles)',
           mediaType: MediaType.BOTH,
-          type: RuleType.TEXT,
+          type: RuleType.TEXT_LIST,
           cacheReset: true,
         },
         {
@@ -322,7 +322,7 @@ export class RuleConstants {
           name: 'playlist_names',
           humanName: '[list] Playlists media is present in (titles)',
           mediaType: MediaType.BOTH,
-          type: RuleType.TEXT,
+          type: RuleType.TEXT_LIST,
         },
         {
           id: 22,
@@ -343,7 +343,7 @@ export class RuleConstants {
           name: 'labels',
           humanName: '[list] Labels',
           mediaType: MediaType.BOTH,
-          type: RuleType.TEXT,
+          type: RuleType.TEXT_LIST,
         },
         {
           id: 25,
@@ -362,7 +362,7 @@ export class RuleConstants {
           mediaType: MediaType.SHOW,
           showType: [EPlexDataType.SEASONS, EPlexDataType.EPISODES],
           cacheReset: true,
-          type: RuleType.TEXT,
+          type: RuleType.TEXT_LIST,
         },
         {
           id: 27,
@@ -377,7 +377,7 @@ export class RuleConstants {
           name: 'watchlist_isListedByUsers',
           humanName: '[list] Watchlisted by (username) [experimental]',
           mediaType: MediaType.BOTH,
-          type: RuleType.TEXT,
+          type: RuleType.TEXT_LIST,
         },
         {
           id: 30,
@@ -516,7 +516,7 @@ export class RuleConstants {
           name: 'tags',
           humanName: '[list] Tags (Text if 1, otherwise list)',
           mediaType: MediaType.MOVIE,
-          type: RuleType.TEXT, // return text[]
+          type: RuleType.TEXT_LIST, // return text[]
         },
         {
           id: 3,
@@ -558,14 +558,14 @@ export class RuleConstants {
           name: 'fileAudioChannels',
           humanName: '[list] File - audio channels',
           mediaType: MediaType.MOVIE,
-          type: RuleType.NUMBER,
+          type: RuleType.NUMBER_LIST,
         },
         {
           id: 9,
           name: 'fileQuality',
           humanName: '[list] File - quality (2160, 1080,..)',
           mediaType: MediaType.MOVIE,
-          type: RuleType.NUMBER,
+          type: RuleType.NUMBER_LIST,
         },
         {
           id: 10,
@@ -669,7 +669,7 @@ export class RuleConstants {
           name: 'tags',
           humanName: '[list] Tags (show)',
           mediaType: MediaType.SHOW,
-          type: RuleType.TEXT, // return text[]
+          type: RuleType.TEXT_LIST, // return text[]
         },
         {
           id: 3,
@@ -875,14 +875,14 @@ export class RuleConstants {
           name: 'seenBy',
           humanName: '[list] Viewed by (username)',
           mediaType: MediaType.MOVIE,
-          type: RuleType.TEXT, // returns usernames []
+          type: RuleType.TEXT_LIST, // returns usernames []
         },
         {
           id: 1,
           name: 'sw_allEpisodesSeenBy',
           humanName: '[list] Users that saw all available episodes',
           mediaType: MediaType.SHOW,
-          type: RuleType.TEXT, // return usernames []
+          type: RuleType.TEXT_LIST, // return usernames []
           showType: [EPlexDataType.SHOWS, EPlexDataType.SEASONS],
         },
         {
@@ -934,7 +934,7 @@ export class RuleConstants {
           name: 'sw_watchers',
           humanName: '[list] Users that watch the show/season/episode',
           mediaType: MediaType.SHOW,
-          type: RuleType.TEXT, // return usernames []
+          type: RuleType.TEXT_LIST, // return usernames []
           showType: [
             EPlexDataType.SHOWS,
             EPlexDataType.SEASONS,

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -13,6 +13,10 @@ export enum RulePossibility {
   NOT_CONTAINS,
   CONTAINS_PARTIAL,
   NOT_CONTAINS_PARTIAL,
+  COUNT_EQUALS,
+  COUNT_NOT_EQUALS,
+  COUNT_BIGGER,
+  COUNT_SMALLER,
 }
 
 export enum RuleOperators {
@@ -50,8 +54,6 @@ export class RuleType {
       RulePossibility.SMALLER,
       RulePossibility.EQUALS,
       RulePossibility.NOT_EQUALS,
-      RulePossibility.CONTAINS,
-      RulePossibility.NOT_CONTAINS,
     ],
     'number',
   );
@@ -74,8 +76,6 @@ export class RuleType {
       RulePossibility.NOT_EQUALS,
       RulePossibility.CONTAINS,
       RulePossibility.NOT_CONTAINS,
-      RulePossibility.CONTAINS_PARTIAL,
-      RulePossibility.NOT_CONTAINS_PARTIAL,
     ],
     'text',
   );
@@ -83,6 +83,38 @@ export class RuleType {
     '3',
     [RulePossibility.EQUALS, RulePossibility.NOT_EQUALS],
     'boolean',
+  );
+  static readonly NUMBER_LIST = new RuleType(
+    '4',
+    [
+      RulePossibility.EQUALS,
+      RulePossibility.NOT_EQUALS,
+      RulePossibility.CONTAINS,
+      RulePossibility.NOT_CONTAINS,
+      RulePossibility.CONTAINS_PARTIAL,
+      RulePossibility.NOT_CONTAINS_PARTIAL,
+      RulePossibility.COUNT_EQUALS,
+      RulePossibility.COUNT_NOT_EQUALS,
+      RulePossibility.COUNT_BIGGER,
+      RulePossibility.COUNT_SMALLER,
+    ],
+    'number list',
+  );
+  static readonly TEXT_LIST = new RuleType(
+    '4',
+    [
+      RulePossibility.EQUALS,
+      RulePossibility.NOT_EQUALS,
+      RulePossibility.CONTAINS,
+      RulePossibility.NOT_CONTAINS,
+      RulePossibility.CONTAINS_PARTIAL,
+      RulePossibility.NOT_CONTAINS_PARTIAL,
+      RulePossibility.COUNT_EQUALS,
+      RulePossibility.COUNT_NOT_EQUALS,
+      RulePossibility.COUNT_BIGGER,
+      RulePossibility.COUNT_SMALLER,
+    ],
+    'text list',
   );
   public constructor(
     private readonly key: string,
@@ -93,6 +125,15 @@ export class RuleType {
     return this.key;
   }
 }
+
+export type RuleValueType =
+  | number
+  | Date
+  | string
+  | boolean
+  | number[]
+  | string[]
+  | null;
 
 export interface Property {
   id: number;

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -218,9 +218,9 @@ export class RuleConstants {
         {
           id: 8,
           name: 'fileVideoResolution',
-          humanName: '[list] Media file resolution (4k, 1080,..)',
+          humanName: 'Media file resolution (4k, 1080,..)',
           mediaType: MediaType.MOVIE,
-          type: RuleType.TEXT_LIST,
+          type: RuleType.TEXT,
         },
         {
           id: 9,
@@ -556,9 +556,9 @@ export class RuleConstants {
         {
           id: 8,
           name: 'fileAudioChannels',
-          humanName: '[list] File - audio channels',
+          humanName: 'File - audio channels',
           mediaType: MediaType.MOVIE,
-          type: RuleType.NUMBER_LIST,
+          type: RuleType.NUMBER,
         },
         {
           id: 9,

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -101,7 +101,7 @@ export class RuleType {
     'number list',
   );
   static readonly TEXT_LIST = new RuleType(
-    '4',
+    '5',
     [
       RulePossibility.EQUALS,
       RulePossibility.NOT_EQUALS,

--- a/server/src/modules/rules/getter/getter.service.ts
+++ b/server/src/modules/rules/getter/getter.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PlexLibraryItem } from '../../../modules/api/plex-api/interfaces/library.interfaces';
-import { Application } from '../constants/rules.constants';
+import { Application, RuleValueType } from '../constants/rules.constants';
 import { OverseerrGetterService } from './overseerr-getter.service';
 import { PlexGetterService } from './plex-getter.service';
 import { RadarrGetterService } from './radarr-getter.service';
@@ -26,7 +26,7 @@ export class ValueGetterService {
     libItem: PlexLibraryItem,
     ruleGroup?: RulesDto,
     dataType?: EPlexDataType,
-  ) {
+  ): Promise<RuleValueType> {
     switch (val1) {
       case Application.PLEX: {
         return await this.plexGetter.get(val2, libItem, dataType, ruleGroup);

--- a/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/server/src/modules/rules/getter/plex-getter.service.ts
@@ -11,6 +11,7 @@ import {
   Application,
   Property,
   RuleConstants,
+  RuleValueType,
 } from '../constants/rules.constants';
 import { RulesDto } from '../dtos/rules.dto';
 
@@ -31,7 +32,7 @@ export class PlexGetterService {
     libItem: PlexLibraryItem,
     dataType?: EPlexDataType,
     ruleGroup?: RulesDto,
-  ) {
+  ): Promise<RuleValueType> {
     try {
       const prop = this.plexProperties.find((el) => el.id === id);
 

--- a/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -517,14 +517,16 @@ export class RuleComparatorService {
     }
 
     if (action === RulePossibility.BEFORE) {
-      assertIsDate(val1);
-      assertIsDate(val2);
+      if (!(val1 instanceof Date) || !(val2 instanceof Date)) {
+        return false;
+      }
       return val1 && val2 ? val1 <= val2 : false;
     }
 
     if (action === RulePossibility.AFTER) {
-      assertIsDate(val1);
-      assertIsDate(val2);
+      if (!(val1 instanceof Date) || !(val2 instanceof Date)) {
+        return false;
+      }
       return val1 && val2 ? val1 >= val2 : false;
     }
 
@@ -542,22 +544,30 @@ export class RuleComparatorService {
       );
     }
 
-    if (action === RulePossibility.COUNT_EQUALS) {
-      assertIsArray(val1);
-      return val1.length === val2;
-    }
     if (action === RulePossibility.COUNT_NOT_EQUALS) {
       return !this.doRuleAction(val1, val2, RulePossibility.COUNT_EQUALS);
     }
-    if (action === RulePossibility.COUNT_BIGGER) {
-      assertIsArray(val1);
-      assertIsNumber(val2);
-      return val1.length > val2;
-    }
-    if (action === RulePossibility.COUNT_SMALLER) {
-      assertIsArray(val1);
-      assertIsNumber(val2);
-      return val1.length < val2;
+    if (
+      [
+        RulePossibility.COUNT_EQUALS,
+        RulePossibility.COUNT_BIGGER,
+        RulePossibility.COUNT_SMALLER,
+      ].includes(action)
+    ) {
+      if (!Array.isArray(val1)) {
+        return false;
+      }
+      if (!Array.isArray(val2) && typeof val2 !== 'number') {
+        return false;
+      }
+      const val2Length = Array.isArray(val2) ? val2.length : val2;
+      if (action === RulePossibility.COUNT_EQUALS) {
+        return val1.length === val2Length;
+      } else if (action === RulePossibility.COUNT_BIGGER) {
+        return val1.length > val2Length;
+      } else if (action === RulePossibility.COUNT_SMALLER) {
+        return val1.length < val2Length;
+      }
     }
   }
 
@@ -568,39 +578,5 @@ export class RuleComparatorService {
     } catch (error) {
       return false;
     }
-  }
-}
-
-function assertIsDate(val: any): asserts val is Date | null {
-  // TODO: remove these explicit null checks + null return values once strictNullChecks is enabled.
-  if (val == null) {
-    return;
-  }
-  if (!(val instanceof Date)) {
-    throw new Error(
-      'Expected a Date but received: ' + JSON.stringify(val, undefined, 2),
-    );
-  }
-}
-
-function assertIsArray<U>(val: any): asserts val is U[] | null {
-  if (val == null) {
-    return;
-  }
-  if (!Array.isArray(val)) {
-    throw new Error(
-      'Expected an array but received: ' + JSON.stringify(val, undefined, 2),
-    );
-  }
-}
-
-function assertIsNumber(val: any): asserts val is number | null {
-  if (val == null) {
-    return;
-  }
-  if (typeof val !== 'number') {
-    throw new Error(
-      'Expected a number but received: ' + JSON.stringify(val, undefined, 2),
-    );
   }
 }

--- a/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -273,7 +273,6 @@ export class RuleComparatorService {
               rule.customVal.ruleTypeId === +RuleType.TEXT_LIST
             ? rule.customVal.value
             : rule.customVal.ruleTypeId === +RuleType.NUMBER ||
-                rule.customVal.ruleTypeId === +RuleType.NUMBER_LIST ||
                 rule.customVal.ruleTypeId === +RuleType.BOOL
               ? +rule.customVal.value
               : null;

--- a/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -269,9 +269,11 @@ export class RuleComparatorService {
           ? rule.customVal.value.includes('-')
             ? new Date(rule.customVal.value)
             : new Date(+rule.customVal.value * 1000)
-          : rule.customVal.ruleTypeId === +RuleType.TEXT
+          : rule.customVal.ruleTypeId === +RuleType.TEXT ||
+              rule.customVal.ruleTypeId === +RuleType.TEXT_LIST
             ? rule.customVal.value
             : rule.customVal.ruleTypeId === +RuleType.NUMBER ||
+                rule.customVal.ruleTypeId === +RuleType.NUMBER_LIST ||
                 rule.customVal.ruleTypeId === +RuleType.BOOL
               ? +rule.customVal.value
               : null;
@@ -295,8 +297,10 @@ export class RuleComparatorService {
         secondVal = new Date(+secondVal);
       }
       if (
-        // if custom secondval is text, check if it's parsable as an array
-        rule.customVal.ruleTypeId === +RuleType.TEXT &&
+        // if custom secondval is text or text list, check if it's parsable as an array
+        [+RuleType.TEXT, +RuleType.TEXT_LIST].includes(
+          rule.customVal.ruleTypeId,
+        ) &&
         typeof secondVal === 'string' &&
         this.isStringParsableToArray(secondVal)
       ) {

--- a/server/src/modules/rules/tests/rule.comparator.service.doRuleAction.spec.ts
+++ b/server/src/modules/rules/tests/rule.comparator.service.doRuleAction.spec.ts
@@ -262,5 +262,54 @@ describe('RuleComparatorService', () => {
       const result = ruleComparatorService['doRuleAction'](val1, val2, action);
       expect(result).toBe(false);
     });
+
+    const listCountData = [
+      // Equality
+      // Text lists
+      [true, ['a1', 'b2', 'c3'], 3, RulePossibility.COUNT_EQUALS],
+      [false, ['a1', 'b2', 'c3'], 4, RulePossibility.COUNT_EQUALS],
+      [false, ['a1', 'b2', 'c3'], 3, RulePossibility.COUNT_NOT_EQUALS],
+      [true, ['a1', 'b2', 'c3'], 4, RulePossibility.COUNT_NOT_EQUALS],
+      // Number lists
+      [true, [1, 2, 3], 3, RulePossibility.COUNT_EQUALS],
+      [false, [1, 2, 3], 4, RulePossibility.COUNT_EQUALS],
+      [false, [1, 2, 3], 3, RulePossibility.COUNT_NOT_EQUALS],
+      [true, [1, 2, 3], 4, RulePossibility.COUNT_NOT_EQUALS],
+
+      // > and <
+      // Text lists
+      [true, ['a1', 'b2', 'c3'], 2, RulePossibility.COUNT_BIGGER],
+      [false, ['a1', 'b2', 'c3'], 3, RulePossibility.COUNT_BIGGER],
+      [false, ['a1', 'b2', 'c3'], 4, RulePossibility.COUNT_BIGGER],
+      [true, ['a1', 'b2', 'c3'], 4, RulePossibility.COUNT_SMALLER],
+      [false, ['a1', 'b2', 'c3'], 3, RulePossibility.COUNT_SMALLER],
+      [false, ['a1', 'b2', 'c3'], 2, RulePossibility.COUNT_SMALLER],
+      // Number lists
+      [true, [1, 2, 3], 2, RulePossibility.COUNT_BIGGER],
+      [false, [1, 2, 3], 3, RulePossibility.COUNT_BIGGER],
+      [false, [1, 2, 3], 4, RulePossibility.COUNT_BIGGER],
+      [true, [1, 2, 3], 4, RulePossibility.COUNT_SMALLER],
+      [false, [1, 2, 3], 3, RulePossibility.COUNT_SMALLER],
+      [false, [1, 2, 3], 2, RulePossibility.COUNT_SMALLER],
+    ] as const;
+    const actionName = {
+      [RulePossibility.COUNT_EQUALS]: 'COUNT_EQUALS',
+      [RulePossibility.COUNT_NOT_EQUALS]: 'COUNT_NOT_EQUALS',
+      [RulePossibility.COUNT_BIGGER]: 'COUNT_BIGGER',
+      [RulePossibility.COUNT_SMALLER]: 'COUNT_SMALLER',
+    };
+    listCountData.forEach(([expected, val1, val2, action]) => {
+      it(`should return ${expected} when val1 is ${JSON.stringify(val1)} and val2 is ${val2} with action ${actionName[action]}`, () => {
+        expect(
+          ruleComparatorService['doRuleAction'](
+            val1 as Writeable<typeof val1>,
+            val2,
+            action,
+          ),
+        ).toBe(expected);
+      });
+    });
   });
 });
+
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };

--- a/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
+++ b/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
@@ -468,10 +468,7 @@ const RuleInput = (props: IRuleInput) => {
                 {ruleType === RuleType.TEXT ? (
                   <option value={CustomParams.CUSTOM_TEXT}>Text</option>
                 ) : undefined}
-                <MaybeNumberOrTextListOptions
-                  ruleType={ruleType}
-                  action={action}
-                />
+                <MaybeTextListOptions ruleType={ruleType} action={action} />
               </optgroup>
               {ConstantsCtx.constants.applications?.map((app) => {
                 return (app.mediaType === MediaType.BOTH ||
@@ -568,7 +565,7 @@ const RuleInput = (props: IRuleInput) => {
   )
 }
 
-function MaybeNumberOrTextListOptions({
+function MaybeTextListOptions({
   ruleType,
   action,
 }: {

--- a/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
+++ b/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
@@ -15,7 +15,6 @@ enum RuleType {
   DATE,
   TEXT,
   BOOL,
-  NUMBER_LIST,
   TEXT_LIST,
 }
 enum RuleOperators {
@@ -25,7 +24,6 @@ enum RuleOperators {
 
 enum CustomParams {
   CUSTOM_NUMBER = 'custom_number',
-  CUSTOM_NUMBER_LIST = 'custom_number_list',
   CUSTOM_DAYS = 'custom_days',
   CUSTOM_DATE = 'custom_date',
   CUSTOM_TEXT = 'custom_text',
@@ -95,10 +93,6 @@ const RuleInput = (props: IRuleInput) => {
             setRuleType(RuleType.BOOL)
             break
           case 4:
-            setSecondVal(CustomParams.CUSTOM_NUMBER_LIST)
-            setRuleType(RuleType.NUMBER_LIST)
-            break
-          case 5:
             setSecondVal(CustomParams.CUSTOM_TEXT_LIST)
             setRuleType(RuleType.TEXT_LIST)
             break
@@ -162,7 +156,6 @@ const RuleInput = (props: IRuleInput) => {
         secondVal !== CustomParams.CUSTOM_DATE &&
         secondVal !== CustomParams.CUSTOM_DAYS &&
         secondVal !== CustomParams.CUSTOM_NUMBER &&
-        secondVal !== CustomParams.CUSTOM_NUMBER_LIST &&
         secondVal !== CustomParams.CUSTOM_TEXT &&
         secondVal !== CustomParams.CUSTOM_TEXT_LIST &&
         secondVal !== CustomParams.CUSTOM_BOOLEAN) ||
@@ -191,9 +184,7 @@ const RuleInput = (props: IRuleInput) => {
                         ? customValType
                         : customValType === RuleType.TEXT_LIST
                           ? customValType
-                          : customValType === RuleType.NUMBER_LIST
-                            ? customValType
-                            : +ruleType
+                          : +ruleType
               : +ruleType,
             value: customVal,
           },
@@ -262,9 +253,6 @@ const RuleInput = (props: IRuleInput) => {
       if (secondVal === CustomParams.CUSTOM_NUMBER) {
         setCustomValActive(true)
         setCustomValType(RuleType.NUMBER)
-      } else if (secondVal === CustomParams.CUSTOM_NUMBER_LIST) {
-        setCustomValActive(true)
-        setCustomValType(RuleType.NUMBER_LIST)
       } else if (secondVal === CustomParams.CUSTOM_DATE) {
         setCustomValActive(true)
         setCustomValType(RuleType.DATE)
@@ -587,12 +575,10 @@ function MaybeNumberOrTextListOptions({
   ruleType: RuleType
   action: string | undefined
 }) {
-  if (action == null) {
+  if (action == null || ruleType !== RuleType.TEXT_LIST) {
     return
   }
-  if (ruleType !== RuleType.NUMBER_LIST && ruleType !== RuleType.TEXT_LIST) {
-    return
-  }
+
   if (
     [
       +RulePossibility.COUNT_EQUALS,
@@ -603,11 +589,8 @@ function MaybeNumberOrTextListOptions({
   ) {
     return <option value={CustomParams.CUSTOM_NUMBER}>Count (number)</option>
   }
-  return ruleType === RuleType.NUMBER_LIST ? (
-    <option value={CustomParams.CUSTOM_NUMBER_LIST}>Number</option>
-  ) : (
-    <option value={CustomParams.CUSTOM_TEXT_LIST}>Text</option>
-  )
+
+  return <option value={CustomParams.CUSTOM_TEXT_LIST}>Text</option>
 }
 
 export default RuleInput

--- a/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
+++ b/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
@@ -1,4 +1,5 @@
 import { TrashIcon } from '@heroicons/react/solid'
+import _ from 'lodash'
 import { FormEvent, useContext, useEffect, useState } from 'react'
 import { IRule } from '../'
 import ConstantsContext, {
@@ -8,7 +9,6 @@ import ConstantsContext, {
   RulePossibilityTranslations,
 } from '../../../../../contexts/constants-context'
 import { EPlexDataType } from '../../../../../utils/PlexDataType-enum'
-import _, { first } from 'lodash'
 
 enum RuleType {
   NUMBER,
@@ -25,9 +25,11 @@ enum RuleOperators {
 
 enum CustomParams {
   CUSTOM_NUMBER = 'custom_number',
+  CUSTOM_NUMBER_LIST = 'custom_number_list',
   CUSTOM_DAYS = 'custom_days',
   CUSTOM_DATE = 'custom_date',
   CUSTOM_TEXT = 'custom_text',
+  CUSTOM_TEXT_LIST = 'custom_text_list',
   CUSTOM_BOOLEAN = 'custom_boolean',
 }
 
@@ -92,6 +94,14 @@ const RuleInput = (props: IRuleInput) => {
             setSecondVal(CustomParams.CUSTOM_BOOLEAN)
             setRuleType(RuleType.BOOL)
             break
+          case 4:
+            setSecondVal(CustomParams.CUSTOM_NUMBER_LIST)
+            setRuleType(RuleType.NUMBER_LIST)
+            break
+          case 5:
+            setSecondVal(CustomParams.CUSTOM_TEXT_LIST)
+            setRuleType(RuleType.TEXT_LIST)
+            break
         }
         setCustomVal(props.editData.rule.customVal.value.toString())
       } else {
@@ -152,7 +162,9 @@ const RuleInput = (props: IRuleInput) => {
         secondVal !== CustomParams.CUSTOM_DATE &&
         secondVal !== CustomParams.CUSTOM_DAYS &&
         secondVal !== CustomParams.CUSTOM_NUMBER &&
+        secondVal !== CustomParams.CUSTOM_NUMBER_LIST &&
         secondVal !== CustomParams.CUSTOM_TEXT &&
+        secondVal !== CustomParams.CUSTOM_TEXT_LIST &&
         secondVal !== CustomParams.CUSTOM_BOOLEAN) ||
         customVal)
     ) {
@@ -177,7 +189,11 @@ const RuleInput = (props: IRuleInput) => {
                       ? customValType
                       : customValType === RuleType.BOOL
                         ? customValType
-                        : +ruleType
+                        : customValType === RuleType.TEXT_LIST
+                          ? customValType
+                          : customValType === RuleType.NUMBER_LIST
+                            ? customValType
+                            : +ruleType
               : +ruleType,
             value: customVal,
           },
@@ -246,6 +262,9 @@ const RuleInput = (props: IRuleInput) => {
       if (secondVal === CustomParams.CUSTOM_NUMBER) {
         setCustomValActive(true)
         setCustomValType(RuleType.NUMBER)
+      } else if (secondVal === CustomParams.CUSTOM_NUMBER_LIST) {
+        setCustomValActive(true)
+        setCustomValType(RuleType.NUMBER_LIST)
       } else if (secondVal === CustomParams.CUSTOM_DATE) {
         setCustomValActive(true)
         setCustomValType(RuleType.DATE)
@@ -255,6 +274,9 @@ const RuleInput = (props: IRuleInput) => {
       } else if (secondVal === CustomParams.CUSTOM_TEXT) {
         setCustomValActive(true)
         setCustomValType(RuleType.TEXT)
+      } else if (secondVal === CustomParams.CUSTOM_TEXT_LIST) {
+        setCustomValActive(true)
+        setCustomValType(RuleType.TEXT_LIST)
       } else if (secondVal === CustomParams.CUSTOM_BOOLEAN) {
         setCustomValActive(true)
         setCustomValType(RuleType.BOOL)
@@ -501,7 +523,7 @@ const RuleInput = (props: IRuleInput) => {
           <div className="form-input">
             <div className="form-input-field">
               {customValType === RuleType.TEXT &&
-              secondVal === 'custom_days' ? (
+              secondVal === CustomParams.CUSTOM_DAYS ? (
                 <input
                   type="number"
                   name="custom_val"
@@ -510,8 +532,9 @@ const RuleInput = (props: IRuleInput) => {
                   value={customVal ? +customVal / 86400 : undefined}
                   placeholder="Amount of days"
                 ></input>
-              ) : customValType === RuleType.TEXT &&
-                secondVal === 'custom_text' ? (
+              ) : (customValType === RuleType.TEXT &&
+                  secondVal === CustomParams.CUSTOM_TEXT) ||
+                customValType === RuleType.TEXT_LIST ? (
                 <input
                   type="text"
                   name="custom_val"
@@ -581,9 +604,9 @@ function MaybeNumberOrTextListOptions({
     return <option value={CustomParams.CUSTOM_NUMBER}>Count (number)</option>
   }
   return ruleType === RuleType.NUMBER_LIST ? (
-    <option value={CustomParams.CUSTOM_NUMBER}>Number</option>
+    <option value={CustomParams.CUSTOM_NUMBER_LIST}>Number</option>
   ) : (
-    <option value={CustomParams.CUSTOM_TEXT}>Text</option>
+    <option value={CustomParams.CUSTOM_TEXT_LIST}>Text</option>
   )
 }
 

--- a/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
+++ b/ui/src/components/Rules/Rule/RuleCreator/RuleInput/index.tsx
@@ -4,31 +4,19 @@ import { IRule } from '../'
 import ConstantsContext, {
   IProperty,
   MediaType,
+  RulePossibility,
   RulePossibilityTranslations,
 } from '../../../../../contexts/constants-context'
 import { EPlexDataType } from '../../../../../utils/PlexDataType-enum'
 import _, { first } from 'lodash'
-
-enum RulePossibility {
-  BIGGER,
-  SMALLER,
-  EQUALS,
-  NOT_EQUALS,
-  CONTAINS,
-  BEFORE,
-  AFTER,
-  IN_LAST,
-  IN_NEXT,
-  NOT_CONTAINS,
-  CONTAINS_PARTIAL,
-  NOT_CONTAINS_PARTIAL,
-}
 
 enum RuleType {
   NUMBER,
   DATE,
   TEXT,
   BOOL,
+  NUMBER_LIST,
+  TEXT_LIST,
 }
 enum RuleOperators {
   AND,
@@ -445,7 +433,7 @@ const RuleInput = (props: IRuleInput) => {
               value={secondVal}
             >
               <option value={undefined}> </option>
-              <optgroup label={`Custom value's`}>
+              <optgroup label="Custom values">
                 {ruleType === RuleType.DATE ? (
                   <>
                     <option value={CustomParams.CUSTOM_DAYS}>
@@ -470,6 +458,10 @@ const RuleInput = (props: IRuleInput) => {
                 {ruleType === RuleType.TEXT ? (
                   <option value={CustomParams.CUSTOM_TEXT}>Text</option>
                 ) : undefined}
+                <MaybeNumberOrTextListOptions
+                  ruleType={ruleType}
+                  action={action}
+                />
               </optgroup>
               {ConstantsCtx.constants.applications?.map((app) => {
                 return (app.mediaType === MediaType.BOTH ||
@@ -562,6 +554,36 @@ const RuleInput = (props: IRuleInput) => {
         </div>
       ) : null}
     </div>
+  )
+}
+
+function MaybeNumberOrTextListOptions({
+  ruleType,
+  action,
+}: {
+  ruleType: RuleType
+  action: string | undefined
+}) {
+  if (action == null) {
+    return
+  }
+  if (ruleType !== RuleType.NUMBER_LIST && ruleType !== RuleType.TEXT_LIST) {
+    return
+  }
+  if (
+    [
+      +RulePossibility.COUNT_EQUALS,
+      +RulePossibility.COUNT_NOT_EQUALS,
+      +RulePossibility.COUNT_BIGGER,
+      +RulePossibility.COUNT_SMALLER,
+    ].includes(+action)
+  ) {
+    return <option value={CustomParams.CUSTOM_NUMBER}>Count (number)</option>
+  }
+  return ruleType === RuleType.NUMBER_LIST ? (
+    <option value={CustomParams.CUSTOM_NUMBER}>Number</option>
+  ) : (
+    <option value={CustomParams.CUSTOM_TEXT}>Text</option>
   )
 }
 

--- a/ui/src/contexts/constants-context.tsx
+++ b/ui/src/contexts/constants-context.tsx
@@ -43,6 +43,10 @@ export enum RulePossibility {
   NOT_CONTAINS,
   CONTAINS_PARTIAL,
   NOT_CONTAINS_PARTIAL,
+  COUNT_EQUALS,
+  COUNT_NOT_EQUALS,
+  COUNT_BIGGER,
+  COUNT_SMALLER,
 }
 
 export enum RulePossibilityTranslations {
@@ -58,6 +62,10 @@ export enum RulePossibilityTranslations {
   NOT_CONTAINS = 'Not Contains (Exact list match)',
   CONTAINS_PARTIAL = 'Contains (Partial list match)',
   NOT_CONTAINS_PARTIAL = 'Not Contains (Partial list match)',
+  COUNT_EQUALS = 'Count Equals',
+  COUNT_NOT_EQUALS = 'Count Does Not Equal',
+  COUNT_BIGGER = 'Count Is Bigger Than',
+  COUNT_SMALLER = 'Count Is Smaller Than',
 }
 
 export const enum MediaType {


### PR DESCRIPTION
This PR:
- Creates new rule types, `NUMBER_LIST` and `TEXT_LIST` (I chose "list" to align with the term already used in the UI/copy)
- Adds new rule actions for those rule types - `COUNT_EQUALS`, `COUNT_NOT_EQUALS`, `COUNT_BIGGER`, `COUNT_SMALLER`
- Moves the existing rule possibilities/actions that were only applicable to lists from `NUMBER` and `TEXT` to the new rule types
- Updates all existing rules that are lists to use the new RuleType
- Adds tests, updates the frontend, etc to accommodate for the new rule type
- Also does a small amount of cleanup of types, which was so I could make sure that I wasn't accidentally missing any cases when updating `doRuleAction` to support the new potential value types. I want to do a lot more cleanup here, but I'll do that in its own refactoring PR instead.

I _think_ this requires no migration, since all rule actions that could have been applicable to list values previously are still valid on the new rule types (it is a superset). But I'm not 100% sure if I'm looking at the right place for how the rule actions are serialised and persisted.

![image](https://github.com/user-attachments/assets/66ff351d-eb62-4ee6-ac76-abab1e4688d7)

![image](https://github.com/user-attachments/assets/d4d5fd2f-3951-4e16-b065-5970ab1a764c)
