### PR TITLE
chore: move from self hosted community rules

### DIFF
--- a/server/src/modules/rules/rules.service.ts
+++ b/server/src/modules/rules/rules.service.ts
@@ -832,6 +832,7 @@ export class RulesService {
       this.logger.log(`Duplicate rule name detected. This is not allowed.`);
       return this.createReturnStatus(false, 'Name already exists');
     }
+    const hasRules = Array.isArray(rule.JsonRules) && rule.JsonRules.length > 0;
 
     return axios
       .patch(this.communityUrl, [
@@ -842,6 +843,7 @@ export class RulesService {
             id: rules.length,
             karma: 5,
             appVersion: appVersion,
+            hasRules,
             ...rule,
           },
         },

--- a/ui/src/components/Collection/CollectionItem/index.tsx
+++ b/ui/src/components/Collection/CollectionItem/index.tsx
@@ -20,7 +20,7 @@ const CollectionItem = (props: ICollectionItem) => {
           : {})}
       >
         {props.collection.media && props.collection.media.length > 1 ? (
-          <div className="z-1 absolute inset-0 flex flex-row overflow-hidden">
+          <div className="absolute inset-0 z-[-100] flex flex-row overflow-hidden">
             <CachedImage
               className="backdrop-image"
               width="600"

--- a/ui/src/components/Common/CommunityRowTableRow/index.tsx
+++ b/ui/src/components/Common/CommunityRowTableRow/index.tsx
@@ -41,13 +41,13 @@ const CommunityRuleTableRow = (props: ICommunityRuleTableRow) => {
       <td
         onClick={onClick}
         onDoubleClick={onDoubleClick}
-        className="md:w-105 whitespace-wrap inline-block max-h-44 w-60 overflow-hidden overflow-ellipsis px-4 py-4 text-left text-sm leading-5 text-white"
+        className="whitespace-wrap inline-block max-h-44 w-60 overflow-hidden overflow-ellipsis px-4 py-4 text-left text-sm leading-5 text-white md:w-96"
       >
         {props.rule.name}
       </td>
       <td className="px-4 py-4 text-center text-sm leading-5 text-white">
         <div
-          className="content-left flex"
+          className="flex items-center justify-center"
           title={
             props.thumbsActive
               ? ''
@@ -80,6 +80,9 @@ const CommunityRuleTableRow = (props: ICommunityRuleTableRow) => {
             }
           />
         </div>
+      </td>
+      <td className="px-4 py-4 text-center text-sm leading-5 text-white">
+        {props.rule.uploadedBy ? props.rule.uploadedBy : '?'}
       </td>
     </tr>
   )

--- a/ui/src/components/Common/CommunityRuleModal/index.tsx
+++ b/ui/src/components/Common/CommunityRuleModal/index.tsx
@@ -30,6 +30,8 @@ export interface ICommunityRule {
   appVersion?: string
   name: string
   description: string
+  hasRules: boolean
+  uploadedBy: string
   JsonRules: IRule[]
 }
 
@@ -130,14 +132,18 @@ const CommunityRuleModal = (props: ICommunityRuleModal) => {
 
   const handleSearch = (input: string) => {
     searchText.current = input
+
     if (input === '') {
       setCommunityRules(originalRules)
     } else {
       setCommunityRules(
         originalRules.filter(
-          (el) =>
-            el.name.toLowerCase().includes(input.trim().toLowerCase()) ||
-            el.description.toLowerCase().includes(input.trim().toLowerCase()),
+          (rule) =>
+            rule.name.toLowerCase().includes(input.trim().toLowerCase()) ||
+            rule.description
+              .toLowerCase()
+              .includes(input.trim().toLowerCase()) ||
+            rule.uploadedBy?.toLowerCase().includes(input.trim().toLowerCase()),
         ),
       )
     }
@@ -221,15 +227,18 @@ const CommunityRuleModal = (props: ICommunityRuleModal) => {
           <div className="flex flex-col">
             <div className="-mx-4 my-2 overflow-x-auto md:mx-0 lg:mx-0">
               <div className="inline-block min-w-full py-2 align-middle">
-                <div className="overflow-hidden rounded-lg shadow md:mx-0 lg:mx-0">
+                <div className="overflow-hidden shadow md:mx-0 lg:mx-0">
                   <table className="ml-2 mr-2 min-w-full table-fixed">
                     <tbody className="divide-y divide-zinc-600 bg-zinc-800">
                       <tr>
-                        <th className="truncate bg-gray-500 px-4 py-3 text-left text-xs font-medium uppercase leading-4 tracking-wider text-gray-200">
+                        <th className="w-60 truncate bg-gray-500 px-4 py-3 text-xs font-medium uppercase text-gray-200 md:w-80">
                           <span>Name</span>
                         </th>
-                        <th className="truncate bg-gray-500 px-4 py-3 text-center text-xs font-medium uppercase leading-4 tracking-wider text-gray-200">
+                        <th className="truncate bg-gray-500 text-center text-xs font-medium uppercase text-gray-200">
                           <span>Karma</span>
+                        </th>
+                        <th className="truncate bg-gray-500 px-3 text-center text-xs font-medium uppercase text-gray-200">
+                          <span>Uploaded By</span>
                         </th>
                       </tr>
                       {shownRules.map((cr) => {

--- a/ui/src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
+++ b/ui/src/components/Rules/Rule/RuleCreator/CommunityRuleUpload/index.tsx
@@ -14,6 +14,7 @@ interface ICommunityRuleUpload {
 const CommunityRuleUpload = (props: ICommunityRuleUpload) => {
   const nameRef = useRef<any>()
   const descriptionRef = useRef<any>()
+  const uploadedByRef = useRef<any>()
   const [thanksModal, setThanksModal] = useState<boolean>(false)
   const [failed, setFailed] = useState<boolean>(false)
 
@@ -24,6 +25,7 @@ const CommunityRuleUpload = (props: ICommunityRuleUpload) => {
         type: props.type,
         description: descriptionRef.current.value,
         JsonRules: props.rules,
+        uploadedBy: uploadedByRef.current.value || undefined,
       })
         .then((resp) => {
           if (resp.code === 1) {
@@ -43,17 +45,18 @@ const CommunityRuleUpload = (props: ICommunityRuleUpload) => {
         loading={false}
         backgroundClickable={false}
         onCancel={props.onCancel}
-        cancelText={'Close'}
+        cancelText={'Cancel'}
         okDisabled={false}
         onOk={handleUpload}
         okText={'Upload'}
         okButtonType={'primary'}
-        title={'Upload Community Rules'}
+        title={'Upload Community Rule'}
         iconSvg={''}
       >
         <div className="mt-6">
           <Alert
-            title={`Please make sure your rules are working correctly. You won't be able to edit them once uploaded`}
+            title={`Every attempt should be made to only upload working rules.
+                    Rules with less than -100 karma and uploads with no rules, are removed nightly.`}
             type="warning"
           />
 
@@ -65,9 +68,9 @@ const CommunityRuleUpload = (props: ICommunityRuleUpload) => {
           ) : undefined}
 
           <form>
-            <div className="form-row">
+            <div className="form-row items-center">
               <label htmlFor="name" className="text-label">
-                Name *
+                Community Short Name *
               </label>
               <div className="form-input">
                 <div className="form-input-field">
@@ -82,9 +85,9 @@ const CommunityRuleUpload = (props: ICommunityRuleUpload) => {
               </div>
             </div>
 
-            <div className="form-row">
+            <div className="form-row items-center">
               <label htmlFor="description" className="text-label">
-                Description *
+                Extended Description *
               </label>
               <div className="form-input">
                 <div className="form-input-field">
@@ -95,6 +98,25 @@ const CommunityRuleUpload = (props: ICommunityRuleUpload) => {
                     rows={5}
                     ref={descriptionRef}
                   ></textarea>
+                </div>
+              </div>
+            </div>
+
+            <div className="form-row items-center">
+              <label htmlFor="uploadedBy" className="text-label">
+                Uploaded by (optional)
+              </label>
+              <div className="form-input">
+                <div className="form-input-field items-center">
+                  <input
+                    className="!bg-zinc-800"
+                    name="uploadedBy"
+                    id="uploadedBy"
+                    type="text"
+                    maxLength={20}
+                    placeholder="Max 20 characters"
+                    ref={uploadedByRef}
+                  ></input>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This PR removes the need for me to self host the community rules, uses a free service (for now) provided by Cloudflare KV, and removes the need to include an API key into the committed code. Adds some automated community rules cleanup as well. There is also a rate limit of 5 per minute to POST or PATCH (new rules or karma) requests to the worker, which will time out for 60 seconds, to avoid spamming.

- Moved the community rules into a Cloudflare Worker/KV flow to remove self-hosted requirement
- Fixed the poster image scroll issue in collection description
- Added an optional "Uploaded by" box to the rule upload
- Added an uploaded by column to the community rule display
- Added uploaded by as search criteria to community rules
- Added a hasRule tag to uploaded rules
- Added a rule scrubber to CF worker that removes uploaded rules with no actual rules attached. (using a hasRules: false tag when empty)
- Added a rule scrubber that removes community rules with less than -100 karma. The automation runs at midnight UTC every day.