### PR TITLE
fix: removed appVersion filtering of community rules.

### DIFF
--- a/ui/src/components/Common/CommunityRuleModal/index.tsx
+++ b/ui/src/components/Common/CommunityRuleModal/index.tsx
@@ -54,11 +54,7 @@ const CommunityRuleModal = (props: ICommunityRuleModal) => {
     GetApiHandler('/rules/community/').then((resp: ICommunityRule[]) => {
       if (resp) {
         if (!('code' in resp)) {
-          resp = resp.filter(
-            (e) =>
-              e.appVersion!.replaceAll('.', '') <=
-                appVersion.current.replaceAll('.', '') && e.type === props.type,
-          )
+          resp = resp.filter((e) => e.type === props.type)
           resp = resp.sort((a, b) => b.karma! - a.karma!)
           setCommunityRules(resp)
           setoriginalRules(resp)


### PR DESCRIPTION
This was causing an issue with some community rules not showing because we were filtering rules based on appVersion. Ensuring that the uploaded rules' appVersion was equal to or lower than the current version of the app. Shouldn't that always be the case? I am not sure why we were doing that in the first place.

This really only became an issue with the comparison to version 2.10.0, and the way we were comparing the versions.