### PR TITLE
feat: Add Jellyseerr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ It's a one-stop-shop for handling those outlying shows and movies that take up p
 
 # Features
 
-- Configure rules specific to your needs, based off of several available options from Plex, Overseerr, Radarr, Sonarr and Tautulli.
+- Configure rules specific to your needs, based off of several available options from Plex, Overseerr, Jellyseerr, Radarr, Sonarr and Tautulli.
 - Manually add media to a collection, in case it's not included after rule execution. (one-off items that don't match a rule set)
 - Selectively exclude media from being added to a collection, even if it matches a rule.
 - Show a collection, containing rule matched media, on the Plex home screen for a specific duration before deletion. Think "Leaving soon".
@@ -44,6 +44,7 @@ Currently, <b>Maintainerr</b> supports rule parameters from these apps :
 
 - Plex
 - Overseerr
+- Jellyseerr
 - Radarr
 - Sonarr
 - Tautulli

--- a/server/src/app/app.module.ts
+++ b/server/src/app/app.module.ts
@@ -16,6 +16,8 @@ import { OverseerrApiService } from '../modules/api/overseerr-api/overseerr-api.
 import ormConfig from './config/typeOrmConfig';
 import { TautulliApiModule } from '../modules/api/tautulli-api/tautulli-api.module';
 import { TautulliApiService } from '../modules/api/tautulli-api/tautulli-api.service';
+import { JellyseerrApiModule } from '../modules/api/jellyseerr-api/jellyseerr-api.module';
+import { JellyseerrApiService } from '../modules/api/jellyseerr-api/jellyseerr-api.service';
 
 @Module({
   imports: [
@@ -27,6 +29,7 @@ import { TautulliApiService } from '../modules/api/tautulli-api/tautulli-api.ser
     ServarrApiModule,
     OverseerrApiModule,
     TautulliApiModule,
+    JellyseerrApiModule,
     RulesModule,
     CollectionsModule,
   ],
@@ -39,6 +42,7 @@ export class AppModule implements OnModuleInit {
     private readonly plexApi: PlexApiService,
     private readonly overseerApi: OverseerrApiService,
     private readonly tautulliApi: TautulliApiService,
+    private readonly jellyseerrApi: JellyseerrApiService,
   ) {}
   async onModuleInit() {
     // Initialize stuff needing settings here.. Otherwise problems
@@ -46,5 +50,6 @@ export class AppModule implements OnModuleInit {
     await this.plexApi.initialize({});
     await this.overseerApi.init();
     await this.tautulliApi.init();
+    await this.jellyseerrApi.init();
   }
 }

--- a/server/src/database/migrations/1740868281450-Add_jellyseerr_settings.ts
+++ b/server/src/database/migrations/1740868281450-Add_jellyseerr_settings.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddJellyseerrSettings1740868281450 implements MigrationInterface {
+  name = 'AddJellyseerrSettings1740868281450';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE settings ADD COLUMN "jellyseerr_url" varchar',
+    );
+    await queryRunner.query(
+      'ALTER TABLE settings ADD COLUMN "jellyseerr_api_key" varchar',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE settings DROP "jellyseerr_url"`);
+    await queryRunner.query(`ALTER TABLE settings DROP "jellyseerr_api_key"`);
+  }
+}

--- a/server/src/modules/api/jellyseerr-api/helpers/jellyseerr-api.helper.ts
+++ b/server/src/modules/api/jellyseerr-api/helpers/jellyseerr-api.helper.ts
@@ -1,0 +1,20 @@
+import { ExternalApiService } from '../../external-api/external-api.service';
+import cacheManager from '../../lib/cache';
+import { Logger } from '@nestjs/common';
+
+export class JellyseerrApi extends ExternalApiService {
+  constructor({ url, apiKey }: { url: string; apiKey: string }) {
+    super(
+      url,
+      {},
+      {
+        headers: {
+          'X-Api-Key': apiKey,
+        },
+        nodeCache: cacheManager.getCache('jellyseerr').data,
+      },
+    );
+
+    this.logger = new Logger(JellyseerrApi.name);
+  }
+}

--- a/server/src/modules/api/jellyseerr-api/jellyseerr-api.controller.ts
+++ b/server/src/modules/api/jellyseerr-api/jellyseerr-api.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Delete, Get, Param } from '@nestjs/common';
+import { JellyseerrApiService } from './jellyseerr-api.service';
+
+@Controller('api/jellyseerr')
+export class JellyseerrApiController {
+  constructor(private readonly jellyseerrApi: JellyseerrApiService) {}
+
+  @Get('movie/:id')
+  getMovie(@Param('id') id: string) {
+    return this.jellyseerrApi.getMovie(id);
+  }
+
+  @Get('show/:id')
+  getShow(@Param('id') id: string) {
+    return this.jellyseerrApi.getShow(id);
+  }
+
+  @Delete('request/:requestId')
+  deleteRequest(@Param('requestId') requestId: string) {
+    return this.jellyseerrApi.deleteRequest(requestId);
+  }
+
+  @Delete('media/:mediaId')
+  deleteMedia(@Param('mediaId') mediaId: string) {
+    return this.jellyseerrApi.deleteMediaItem(mediaId);
+  }
+  @Delete('media/tmdb/:mediaId')
+  removeMediaByTmdbId(@Param('mediaId') mediaId: string) {
+    return this.jellyseerrApi.removeMediaByTmdbId(mediaId, 'movie');
+  }
+}

--- a/server/src/modules/api/jellyseerr-api/jellyseerr-api.module.ts
+++ b/server/src/modules/api/jellyseerr-api/jellyseerr-api.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { JellyseerrApiService } from './jellyseerr-api.service';
+import { JellyseerrApiController } from './jellyseerr-api.controller';
+import { ExternalApiModule } from '../external-api/external-api.module';
+
+@Module({
+  imports: [ExternalApiModule],
+  providers: [JellyseerrApiService],
+  controllers: [JellyseerrApiController],
+  exports: [JellyseerrApiService],
+})
+export class JellyseerrApiModule {}

--- a/server/src/modules/api/jellyseerr-api/jellyseerr-api.service.ts
+++ b/server/src/modules/api/jellyseerr-api/jellyseerr-api.service.ts
@@ -1,0 +1,353 @@
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import { SettingsService } from '../../settings/settings.service';
+import { JellyseerrApi } from './helpers/jellyseerr-api.helper';
+
+export interface JellyseerrMediaResponse {
+  id: number;
+  imdbid: string;
+  collection: JellyseerrCollection;
+  mediaInfo: JellyseerrMediaInfo;
+  releaseDate?: Date;
+  firstAirDate?: Date;
+}
+interface JellyseerrCollection {
+  id: number;
+  name: string;
+  posterPath: string;
+  backdropPath: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface JellyseerrMediaInfo {
+  id: number;
+  tmdbId: number;
+  tvdbId: number;
+  status: number;
+  updatedAt: string;
+  mediaAddedAt: string;
+  externalServiceId: number;
+  externalServiceId4k: number;
+  requests?: JellyseerrRequest[];
+  seasons?: JellyseerrSeason[];
+}
+
+export interface JellyseerrRequest {
+  id: number;
+  status: number;
+  media: JellyseerrMedia;
+  createdAt: string;
+  updatedAt: string;
+  requestedBy: JellyseerrUser;
+  modifiedBy: JellyseerrUser;
+  is4k: false;
+  serverId: number;
+  profileId: number;
+  rootFolder: string;
+  seasons: JellyseerrSeason[];
+}
+
+interface JellyseerrUser {
+  id: number;
+  email: string;
+  username: string;
+  plexToken: string;
+  plexId?: number;
+  plexUsername: string;
+  userType: number;
+  permissions: number;
+  avatar: string;
+  createdAt: string;
+  updatedAt: string;
+  requestCount: number;
+}
+
+export interface JellyseerrSeason {
+  id: number;
+  name: string;
+  seasonNumber: number;
+  requestedBy: JellyseerrUser;
+  // episodes: JellyseerrEpisode[];
+}
+
+interface JellyseerrStatus {
+  version: string;
+  commitTag: string;
+  updateAvailable: boolean;
+  commitsBehind: number;
+}
+
+export enum JellyseerrMediaStatus {
+  UNKNOWN = 1,
+  PENDING,
+  PROCESSING,
+  PARTIALLY_AVAILABLE,
+  AVAILABLE,
+}
+
+export interface JellyseerrBasicApiResponse {
+  code: string;
+  description: string;
+}
+
+interface JellyseerrMedia {
+  downloadStatus: [];
+  downloadStatus4k: [];
+  id: number;
+  mediaType: 'movie' | 'tv';
+  tmdbId: number;
+  tvdbId: number;
+  imdbId: number;
+  status: number;
+  status4k: number;
+  createdAt: string;
+  updatedAt: string;
+  lastSeasonChange: string;
+  mediaAddedAt: string;
+  serviceId: number;
+  serviceId4k: number;
+  externalServiceId: number;
+  externalServiceId4k: number;
+  externalServiceSlug: string;
+  externalServiceSlug4k: number;
+  ratingKey: string;
+  ratingKey4k: number;
+  seasons: [];
+  plexUrl: string;
+  serviceUrl: string;
+}
+
+interface JellyseerrUserResponse {
+  pageInfo: {
+    pages: number;
+    pageSize: number;
+    results: number;
+    page: number;
+  };
+  results: JellyseerrUserResponseResult[];
+}
+
+interface JellyseerrUserResponseResult {
+  permissions: number;
+  id: number;
+  email: string;
+  plexUsername: string;
+  username: string;
+  userType: number;
+  plexId: number;
+  avatar: string;
+  createdAt: string;
+  updatedAt: string;
+  requestCount: number;
+  displayName: string;
+}
+
+@Injectable()
+export class JellyseerrApiService {
+  api: JellyseerrApi;
+
+  private readonly logger = new Logger(JellyseerrApiService.name);
+  constructor(
+    @Inject(forwardRef(() => SettingsService))
+    private readonly settings: SettingsService,
+  ) {}
+
+  public async init() {
+    this.api = new JellyseerrApi({
+      url: `${this.settings.jellyseerr_url?.replace(/\/$/, '')}/api/v1`,
+      apiKey: `${this.settings.jellyseerr_api_key}`,
+    });
+  }
+
+  public async getMovie(id: string | number): Promise<JellyseerrMediaResponse> {
+    try {
+      const response: JellyseerrMediaResponse = await this.api.get(
+        `/movie/${id}`,
+      );
+      return response;
+    } catch (err) {
+      this.logger.warn(
+        'Jellyseerr communication failed. Is the application running?',
+      );
+      this.logger.debug(err);
+      return undefined;
+    }
+  }
+
+  public async getShow(
+    showId: string | number,
+    season?: string,
+  ): Promise<JellyseerrMediaResponse> {
+    try {
+      if (showId) {
+        const response: JellyseerrMediaResponse = season
+          ? await this.api.get(`/tv/${showId}/season/${season}`)
+          : await this.api.get(`/tv/${showId}`);
+        return response;
+      }
+      return undefined;
+    } catch (err) {
+      this.logger.warn(
+        'Jellyseerr communication failed. Is the application running?',
+      );
+      this.logger.debug(err);
+      return undefined;
+    }
+  }
+
+  public async getUsers(): Promise<any> {
+    try {
+      const size = 50;
+      let hasNext = true;
+      let skip = 0;
+
+      const users: JellyseerrUserResponseResult[] = [];
+
+      while (hasNext) {
+        const resp: JellyseerrUserResponse = await this.api.get(
+          `/user?take=${size}&skip=${skip}`,
+        );
+
+        users.push(...resp.results);
+
+        if (resp?.pageInfo?.page < resp?.pageInfo?.pages) {
+          skip = skip + size;
+        } else {
+          hasNext = false;
+        }
+      }
+      return users;
+    } catch (err) {
+      this.logger.warn(
+        `Couldn't fetch Jellyseerr users. Is the application running?`,
+      );
+      this.logger.debug(err);
+      return [];
+    }
+  }
+
+  public async deleteRequest(requestId: string) {
+    try {
+      const response: JellyseerrBasicApiResponse = await this.api.delete(
+        `/request/${requestId}`,
+      );
+      return response;
+    } catch (err) {
+      this.logger.warn(
+        'Jellyseerr communication failed. Is the application running?',
+        err,
+      );
+      this.logger.debug(err);
+      return undefined;
+    }
+  }
+
+  public async removeSeasonRequest(tmdbid: string | number, season: number) {
+    try {
+      const media = await this.getShow(tmdbid);
+
+      if (media && media.mediaInfo) {
+        const requests = media.mediaInfo.requests.filter((el) =>
+          el.seasons.find((s) => s.seasonNumber === season),
+        );
+        if (requests.length > 0) {
+          requests.forEach((el) => {
+            this.deleteRequest(el.id.toString());
+          });
+        } else {
+          // no requests ? clear data and let Jellyseerr refetch.
+          await this.api.delete(`/media/${media.id}`);
+        }
+
+        // can't clear season data. Overserr doesn't have media ID's for seasons...
+
+        // const seasons = media.mediaInfo.seasons?.filter(
+        //   (el) => el.seasonNumber === season,
+        // );
+
+        // if (seasons.length > 0) {
+        //   for (const el of seasons) {
+        //     const resp = await this.api.post(`/media/${el.id}/unknown`);
+        //     console.log(resp);
+        //   }
+        // }
+      }
+    } catch (err) {
+      this.logger.warn(
+        'Jellyseerr communication failed. Is the application running?',
+        err,
+      );
+      this.logger.debug(err);
+      return undefined;
+    }
+  }
+
+  public async deleteMediaItem(mediaId: string | number) {
+    try {
+      const response: JellyseerrBasicApiResponse = await this.api.delete(
+        `/media/${mediaId}`,
+      );
+      return response;
+    } catch (e) {
+      this.logger.log("Couldn't delete media. Does it exist in Jellyseerr?", {
+        label: 'Jellyseerr API',
+        errorMessage: e.message,
+        mediaId,
+      });
+      this.logger.debug(e);
+      return null;
+    }
+  }
+
+  public async removeMediaByTmdbId(id: string | number, type: 'movie' | 'tv') {
+    try {
+      let media: JellyseerrMediaResponse;
+      if (type === 'movie') {
+        media = await this.getMovie(id);
+      } else {
+        media = await this.getShow(id);
+      }
+      if (media && media.mediaInfo) {
+        try {
+          if (media.mediaInfo.id) {
+            this.deleteMediaItem(media.mediaInfo.id.toString());
+          }
+        } catch (e) {
+          this.logger.log(
+            "Couldn't delete media. Does it exist in Jellyseerr?",
+            {
+              label: 'Jellyseerr API',
+              errorMessage: e.message,
+              id,
+            },
+          );
+        }
+      }
+    } catch (err) {
+      this.logger.warn(
+        'Jellyseerr communication failed. Is the application running?',
+      );
+      this.logger.debug(err);
+      return undefined;
+    }
+  }
+
+  public async status(): Promise<JellyseerrStatus> {
+    try {
+      const response: JellyseerrStatus = await this.api.getWithoutCache(
+        `/status`,
+        {
+          signal: AbortSignal.timeout(10000), // aborts request after 10 seconds
+        },
+      );
+      return response;
+    } catch (e) {
+      this.logger.log("Couldn't fetch Jellyseerr status!", {
+        label: 'Jellyseerr API',
+        errorMessage: e.message,
+      });
+      this.logger.debug(e);
+      return null;
+    }
+  }
+}

--- a/server/src/modules/api/lib/cache.ts
+++ b/server/src/modules/api/lib/cache.ts
@@ -6,7 +6,8 @@ type AvailableCacheIds =
   | 'plextv'
   | 'overseerr'
   | 'plexcommunity'
-  | 'tautulli';
+  | 'tautulli'
+  | 'jellyseerr';
 
 type CacheType = AvailableCacheIds | 'radarr' | 'sonarr';
 
@@ -63,6 +64,7 @@ class CacheManager {
       'plexcommunity',
     ),
     tautulli: new Cache('tautulli', 'Tautulli API', 'tautulli'),
+    jellyseerr: new Cache('jellyseerr', 'Jellyseerr API', 'jellyseerr'),
   };
 
   public createCache(

--- a/server/src/modules/collections/collections.module.ts
+++ b/server/src/modules/collections/collections.module.ts
@@ -15,6 +15,7 @@ import { Exclusion } from '../rules/entities/exclusion.entities';
 import { CollectionLog } from '../collections/entities/collection_log.entities';
 import { CollectionLogCleanerService } from '../collections/tasks/collection-log-cleaner.service';
 import { TautulliApiModule } from '../api/tautulli-api/tautulli-api.module';
+import { JellyseerrApiModule } from '../api/jellyseerr-api/jellyseerr-api.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { TautulliApiModule } from '../api/tautulli-api/tautulli-api.module';
     ]),
     OverseerrApiModule,
     TautulliApiModule,
+    JellyseerrApiModule,
     TmdbApiModule,
     ServarrApiModule,
     TasksModule,

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -26,6 +26,7 @@ export const enum Application {
   SONARR,
   OVERSEERR,
   TAUTULLI,
+  JELLYSEERR,
 }
 
 export const enum ArrAction {
@@ -796,6 +797,62 @@ export class RuleConstants {
             EPlexDataType.SEASONS,
             EPlexDataType.EPISODES,
           ],
+        },
+      ],
+    },
+    {
+      id: Application.JELLYSEERR,
+      name: 'Jellyseerr',
+      mediaType: MediaType.BOTH,
+      props: [
+        {
+          id: 0,
+          name: 'addUser',
+          humanName: 'Requested by user (Plex or local username)',
+          mediaType: MediaType.BOTH,
+          type: RuleType.TEXT,
+        }, //  returns username[]
+        {
+          id: 1,
+          name: 'requestDate',
+          humanName: 'Request date',
+          mediaType: MediaType.BOTH,
+          type: RuleType.DATE,
+        },
+        {
+          id: 2,
+          name: 'releaseDate',
+          humanName: 'Release/air date',
+          mediaType: MediaType.BOTH,
+          type: RuleType.DATE,
+        },
+        {
+          id: 3,
+          name: 'approvalDate',
+          humanName: 'Approval date',
+          mediaType: MediaType.BOTH,
+          type: RuleType.DATE,
+        },
+        {
+          id: 4,
+          name: 'mediaAddedAt',
+          humanName: 'Media downloaded date',
+          mediaType: MediaType.BOTH,
+          type: RuleType.DATE,
+        },
+        {
+          id: 5,
+          name: 'amountRequested',
+          humanName: 'Amount of requests',
+          mediaType: MediaType.BOTH,
+          type: RuleType.NUMBER,
+        },
+        {
+          id: 6,
+          name: 'isRequested',
+          humanName: 'Requested in Jellyseerr',
+          mediaType: MediaType.BOTH,
+          type: RuleType.BOOL,
         },
       ],
     },

--- a/server/src/modules/rules/getter/getter.service.ts
+++ b/server/src/modules/rules/getter/getter.service.ts
@@ -8,6 +8,7 @@ import { SonarrGetterService } from './sonarr-getter.service';
 import { RulesDto } from '../dtos/rules.dto';
 import { EPlexDataType } from '../../api/plex-api/enums/plex-data-type-enum';
 import { TautulliGetterService } from './tautulli-getter.service';
+import { JellyseerrGetterService } from './jellyseerr-getter.service';
 
 @Injectable()
 export class ValueGetterService {
@@ -17,6 +18,7 @@ export class ValueGetterService {
     private readonly sonarrGetter: SonarrGetterService,
     private readonly overseerGetter: OverseerrGetterService,
     private readonly tautulliGetter: TautulliGetterService,
+    private readonly jellyseerrGetter: JellyseerrGetterService,
   ) {}
 
   async get(
@@ -45,6 +47,9 @@ export class ValueGetterService {
           dataType,
           ruleGroup,
         );
+      }
+      case Application.JELLYSEERR: {
+        return await this.jellyseerrGetter.get(val2, libItem, dataType);
       }
       default: {
         return null;

--- a/server/src/modules/rules/getter/jellyseerr-getter.service.ts
+++ b/server/src/modules/rules/getter/jellyseerr-getter.service.ts
@@ -1,0 +1,312 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { warn } from 'console';
+import {
+  JellyseerrApiService,
+  JellyseerrMediaResponse,
+  JellyseerrMediaStatus,
+  JellyseerrRequest,
+} from '../../api/jellyseerr-api/jellyseerr-api.service';
+import { PlexLibraryItem } from '../../api/plex-api/interfaces/library.interfaces';
+import { PlexApiService } from '../../api/plex-api/plex-api.service';
+import { TmdbIdService } from '../../api/tmdb-api/tmdb-id.service';
+import { TmdbApiService } from '../../api/tmdb-api/tmdb.service';
+import {
+  Application,
+  Property,
+  RuleConstants,
+} from '../constants/rules.constants';
+import { EPlexDataType } from '../../api/plex-api/enums/plex-data-type-enum';
+import _ from 'lodash';
+
+@Injectable()
+export class JellyseerrGetterService {
+  appProperties: Property[];
+  private readonly logger = new Logger(JellyseerrGetterService.name);
+
+  constructor(
+    private readonly jellyseerrApi: JellyseerrApiService,
+    private readonly tmdbApi: TmdbApiService,
+    private readonly plexApi: PlexApiService,
+    private readonly tmdbIdHelper: TmdbIdService,
+  ) {
+    const ruleConstanst = new RuleConstants();
+    this.appProperties = ruleConstanst.applications.find(
+      (el) => el.id === Application.JELLYSEERR,
+    ).props;
+  }
+
+  async get(id: number, libItem: PlexLibraryItem, dataType?: EPlexDataType) {
+    try {
+      let origLibItem = undefined;
+      let seasonMediaResponse = undefined;
+
+      // get original show in case of season / episode
+      if (
+        dataType === EPlexDataType.SEASONS ||
+        dataType === EPlexDataType.EPISODES
+      ) {
+        origLibItem = _.cloneDeep(libItem);
+        libItem = (await this.plexApi.getMetadata(
+          dataType === EPlexDataType.SEASONS
+            ? libItem.parentRatingKey
+            : libItem.grandparentRatingKey,
+        )) as unknown as PlexLibraryItem;
+      }
+
+      const prop = this.appProperties.find((el) => el.id === id);
+      const tmdb = await this.tmdbIdHelper.getTmdbIdFromPlexData(libItem);
+      // const jellyseerrUsers = await this.jellyseerrApi.getUsers();
+
+      let mediaResponse: JellyseerrMediaResponse;
+      if (tmdb && tmdb.id) {
+        if (libItem.type === 'movie') {
+          mediaResponse = await this.jellyseerrApi.getMovie(tmdb.id.toString());
+        } else {
+          mediaResponse = await this.jellyseerrApi.getShow(tmdb.id.toString());
+          if (
+            dataType === EPlexDataType.SEASONS ||
+            dataType === EPlexDataType.EPISODES
+          ) {
+            seasonMediaResponse = await this.jellyseerrApi.getShow(
+              tmdb.id.toString(),
+              dataType === EPlexDataType.SEASONS
+                ? origLibItem.index
+                : origLibItem.parentIndex,
+            );
+            if (!seasonMediaResponse) {
+              this.logger.debug(
+                `Couldn't fetch season data for '${libItem.title}' season ${
+                  dataType === EPlexDataType.SEASONS
+                    ? origLibItem.index
+                    : origLibItem.parentIndex
+                } from Jellyseerr. As a result, unreliable results are expected.`,
+              );
+            }
+          }
+        }
+      } else {
+        this.logger.debug(
+          `Couldn't find tmdb id for media '${libItem.title}' with id '${libItem.ratingKey}'. As a result, no Jellyseerr query could be made.`,
+        );
+      }
+
+      if (mediaResponse && mediaResponse.mediaInfo) {
+        switch (prop.name) {
+          case 'addUser': {
+            try {
+              const plexUsers = await this.plexApi.getCorrectedUsers();
+              const userNames: string[] = [];
+              if (
+                mediaResponse &&
+                mediaResponse.mediaInfo &&
+                mediaResponse.mediaInfo.requests
+              ) {
+                for (const request of mediaResponse.mediaInfo.requests) {
+                  // for seasons, only add if user requested the correct season
+                  if (
+                    dataType === EPlexDataType.SEASONS ||
+                    dataType === EPlexDataType.EPISODES
+                  ) {
+                    const includesSeason = this.includesSeason(
+                      request,
+                      dataType === EPlexDataType.SEASONS
+                        ? origLibItem.index
+                        : origLibItem.parentIndex,
+                    );
+                    if (includesSeason) {
+                      if (request.requestedBy?.userType === 2) {
+                        userNames.push(request.requestedBy?.username);
+                      } else {
+                        const user = plexUsers.find(
+                          (u) => u.plexId === request.requestedBy?.plexId,
+                        )?.username;
+
+                        if (user) {
+                          userNames.push(user);
+                        }
+                      }
+                    }
+                  } else {
+                    // for shows and movies, add every request user
+                    if (request.requestedBy?.userType === 2) {
+                      userNames.push(request.requestedBy?.username);
+                    } else {
+                      const user = plexUsers.find(
+                        (u) => u.plexId === request.requestedBy?.plexId,
+                      )?.username;
+
+                      if (user) {
+                        userNames.push(user);
+                      }
+                    }
+                  }
+                }
+                return [...new Set(userNames)]; // return only unique usernames
+              }
+              return [];
+            } catch (e) {
+              this.logger.warn("Couldn't get addUser from Jellyseerr");
+              this.logger.debug(e);
+            }
+          }
+          case 'amountRequested': {
+            return [EPlexDataType.SEASONS, EPlexDataType.EPISODES].includes(
+              dataType,
+            )
+              ? this.getSeasonRequests(origLibItem, mediaResponse).length
+              : mediaResponse?.mediaInfo.requests.length;
+          }
+          case 'requestDate': {
+            if (
+              [EPlexDataType.SEASONS, EPlexDataType.EPISODES].includes(dataType)
+            ) {
+              return this.getSeasonRequests(origLibItem, mediaResponse)[0]
+                ?.createdAt
+                ? new Date(
+                    this.getSeasonRequests(
+                      origLibItem,
+                      mediaResponse,
+                    )[0]?.createdAt,
+                  )
+                : null;
+            }
+            return mediaResponse?.mediaInfo?.requests[0]?.createdAt
+              ? new Date(mediaResponse?.mediaInfo?.requests[0]?.createdAt)
+              : null;
+          }
+          case 'releaseDate': {
+            if (libItem.type === 'movie') {
+              return mediaResponse?.releaseDate
+                ? new Date(mediaResponse?.releaseDate)
+                : null;
+            } else {
+              if (EPlexDataType.EPISODES === dataType) {
+                const ep = seasonMediaResponse.episodes?.find(
+                  (el) => el.episodeNumber === origLibItem.index,
+                );
+                return ep?.airDate
+                  ? new Date(ep.airDate)
+                  : ep?.firstAirDate
+                    ? new Date(ep.firstAirDate)
+                    : null;
+              } else if (EPlexDataType.SEASONS === dataType) {
+                return seasonMediaResponse?.airDate
+                  ? new Date(seasonMediaResponse.airDate)
+                  : seasonMediaResponse?.firstAirDate
+                    ? new Date(seasonMediaResponse.firstAirDate)
+                    : null;
+              } else {
+                return mediaResponse?.firstAirDate
+                  ? new Date(mediaResponse.firstAirDate)
+                  : null;
+              }
+            }
+          }
+          case 'approvalDate': {
+            if (
+              [EPlexDataType.SEASONS, EPlexDataType.EPISODES].includes(dataType)
+            ) {
+              const season = this.getSeasonRequests(
+                origLibItem,
+                mediaResponse,
+              )[0];
+              if (season && season.media) {
+                if (
+                  season.media.status >=
+                  JellyseerrMediaStatus.PARTIALLY_AVAILABLE
+                ) {
+                  return new Date(season.media.updatedAt);
+                }
+              }
+              return null;
+            } else {
+              return mediaResponse?.mediaInfo.status >=
+                JellyseerrMediaStatus.PARTIALLY_AVAILABLE
+                ? new Date(mediaResponse?.mediaInfo?.updatedAt)
+                : null;
+            }
+          }
+          case 'mediaAddedAt': {
+            if (
+              [EPlexDataType.SEASONS, EPlexDataType.EPISODES].includes(dataType)
+            ) {
+              const season = this.getSeasonRequests(
+                origLibItem,
+                mediaResponse,
+              )[0];
+              if (season && season.media) {
+                if (
+                  season.media.status >=
+                  JellyseerrMediaStatus.PARTIALLY_AVAILABLE
+                ) {
+                  return new Date(season.media.mediaAddedAt);
+                }
+              }
+              return null;
+            } else {
+              return mediaResponse?.mediaInfo.status >=
+                JellyseerrMediaStatus.PARTIALLY_AVAILABLE
+                ? new Date(mediaResponse?.mediaInfo?.mediaAddedAt)
+                : null;
+            }
+          }
+          case 'isRequested': {
+            try {
+              if (
+                [EPlexDataType.SEASONS, EPlexDataType.EPISODES].includes(
+                  dataType,
+                )
+              ) {
+                return this.getSeasonRequests(origLibItem, mediaResponse)
+                  .length > 0
+                  ? 1
+                  : 0;
+              } else {
+                return mediaResponse?.mediaInfo.requests.length > 0 ? 1 : 0;
+              }
+            } catch (e) {
+              return 0;
+            }
+          }
+          default: {
+            return null;
+          }
+        }
+      } else {
+        this.logger.debug(
+          `Couldn't fetch Jellyseerr metadate for media '${libItem.title}' with id '${libItem.ratingKey}'. As a result, no Jellyseerr query could be made.`,
+        );
+        return null;
+      }
+    } catch (e) {
+      warn(`Jellyseerr-Getter - Action failed : ${e.message}`);
+      this.logger.debug(e);
+      return undefined;
+    }
+  }
+
+  private getSeasonRequests(
+    libItem: PlexLibraryItem,
+    mediaResponse: JellyseerrMediaResponse,
+  ) {
+    const seasonRequests: JellyseerrRequest[] = [];
+    mediaResponse.mediaInfo?.requests.forEach((el) => {
+      const season = el.seasons.find(
+        (season) =>
+          +season.seasonNumber ===
+          (libItem.type === 'episode' ? +libItem.parentIndex : +libItem.index),
+      );
+      if (season) {
+        seasonRequests.push(el);
+      }
+    });
+    return seasonRequests;
+  }
+
+  private includesSeason(request: JellyseerrRequest, seasonNumber: number) {
+    const season = request.seasons.find(
+      (season) => season.seasonNumber === seasonNumber,
+    );
+    return season !== undefined;
+  }
+}

--- a/server/src/modules/rules/rules.module.ts
+++ b/server/src/modules/rules/rules.module.ts
@@ -30,6 +30,8 @@ import { TautulliApiModule } from '../api/tautulli-api/tautulli-api.module';
 import { TautulliGetterService } from './getter/tautulli-getter.service';
 import { RadarrSettings } from '../settings/entities/radarr_settings.entities';
 import { SonarrSettings } from '../settings/entities/sonarr_settings.entities';
+import { JellyseerrApiModule } from '../api/jellyseerr-api/jellyseerr-api.module';
+import { JellyseerrGetterService } from './getter/jellyseerr-getter.service';
 
 @Module({
   imports: [
@@ -48,6 +50,7 @@ import { SonarrSettings } from '../settings/entities/sonarr_settings.entities';
     ]),
     OverseerrApiModule,
     TautulliApiModule,
+    JellyseerrApiModule,
     TmdbApiModule,
     CollectionsModule,
     TasksModule,
@@ -62,6 +65,7 @@ import { SonarrSettings } from '../settings/entities/sonarr_settings.entities';
     SonarrGetterService,
     OverseerrGetterService,
     TautulliGetterService,
+    JellyseerrGetterService,
     ValueGetterService,
     RuleYamlService,
     RuleComparatorService,

--- a/server/src/modules/rules/rules.service.ts
+++ b/server/src/modules/rules/rules.service.ts
@@ -106,6 +106,13 @@ export class RulesService {
           (el) => el.id !== Application.TAUTULLI,
         );
       }
+
+      // remove jellyseerr if not configured
+      if (!settings.jellyseerr_url || !settings.jellyseerr_api_key) {
+        localConstants.applications = localConstants.applications.filter(
+          (el) => el.id !== Application.JELLYSEERR,
+        );
+      }
     }
 
     return localConstants;
@@ -944,6 +951,7 @@ export class RulesService {
     this.plexApi.resetMetadataCache(mediaId);
     cacheManager.getCache('overseerr').data.flushAll();
     cacheManager.getCache('tautulli').data.flushAll();
+    cacheManager.getCache('jellyseerr').flush();
     cacheManager
       .getCachesByType('radarr')
       .forEach((cache) => cache.data.flushAll());

--- a/server/src/modules/settings/dto's/setting.dto.ts
+++ b/server/src/modules/settings/dto's/setting.dto.ts
@@ -31,6 +31,10 @@ export class SettingDto {
 
   tautulli_api_key: string;
 
+  jellyseerr_url: string;
+
+  jellyseerr_api_key: string;
+
   collection_handler_job_cron: string;
 
   rules_handler_job_cron: string;

--- a/server/src/modules/settings/entities/settings.entities.ts
+++ b/server/src/modules/settings/entities/settings.entities.ts
@@ -53,6 +53,12 @@ export class Settings implements SettingDto {
   @Column({ nullable: true })
   tautulli_api_key: string;
 
+  @Column({ nullable: true })
+  jellyseerr_url: string;
+
+  @Column({ nullable: true })
+  jellyseerr_api_key: string;
+
   @Column({ nullable: false, default: CronExpression.EVERY_12_HOURS })
   collection_handler_job_cron: string;
 

--- a/server/src/modules/settings/settings.controller.ts
+++ b/server/src/modules/settings/settings.controller.ts
@@ -60,6 +60,10 @@ export class SettingsController {
   testOverseerr() {
     return this.settingsService.testOverseerr();
   }
+  @Get('/test/jellyseerr')
+  testJellyseerr() {
+    return this.settingsService.testJellyseerr();
+  }
   @Post('/test/radarr')
   testRadarr(@Body() payload: RadarrSettingRawDto) {
     return this.settingsService.testRadarr(payload);

--- a/server/src/modules/settings/settings.module.ts
+++ b/server/src/modules/settings/settings.module.ts
@@ -10,6 +10,7 @@ import { InternalApiModule } from '../api/internal-api/internal-api.module';
 import { TautulliApiModule } from '../api/tautulli-api/tautulli-api.module';
 import { RadarrSettings } from './entities/radarr_settings.entities';
 import { SonarrSettings } from './entities/sonarr_settings.entities';
+import { JellyseerrApiModule } from '../api/jellyseerr-api/jellyseerr-api.module';
 
 @Global()
 @Module({
@@ -17,6 +18,7 @@ import { SonarrSettings } from './entities/sonarr_settings.entities';
     forwardRef(() => PlexApiModule),
     forwardRef(() => ServarrApiModule),
     forwardRef(() => OverseerrApiModule),
+    forwardRef(() => JellyseerrApiModule),
     forwardRef(() => TautulliApiModule),
     forwardRef(() => InternalApiModule),
     TypeOrmModule.forFeature([Settings, RadarrSettings]),

--- a/ui/src/components/Settings/Jellyseerr/index.tsx
+++ b/ui/src/components/Settings/Jellyseerr/index.tsx
@@ -1,0 +1,225 @@
+import { SaveIcon } from '@heroicons/react/solid'
+import { useContext, useEffect, useRef, useState } from 'react'
+import SettingsContext from '../../../contexts/settings-context'
+import { PostApiHandler } from '../../../utils/ApiHandler'
+import Alert from '../../Common/Alert'
+import Button from '../../Common/Button'
+import DocsButton from '../../Common/DocsButton'
+import TestButton from '../../Common/TestButton'
+import {
+  addPortToUrl,
+  getPortFromUrl,
+  handleSettingsInputChange,
+  removePortFromUrl,
+} from '../../../utils/SettingsUtils'
+
+const JellyseerrSettings = () => {
+  const settingsCtx = useContext(SettingsContext)
+  const hostnameRef = useRef<HTMLInputElement>(null)
+  const portRef = useRef<HTMLInputElement>(null)
+  const apiKeyRef = useRef<HTMLInputElement>(null)
+  const [hostname, setHostname] = useState<string>()
+  const [port, setPort] = useState<string>()
+  const [error, setError] = useState<boolean>()
+  const [changed, setChanged] = useState<boolean>()
+  const [testBanner, setTestbanner] = useState<{
+    status: boolean
+    version: string
+  }>({ status: false, version: '0' })
+
+  useEffect(() => {
+    document.title = 'Maintainerr - Settings - Jellyseerr'
+  }, [])
+
+  useEffect(() => {
+    // hostname
+    setHostname(removePortFromUrl(settingsCtx.settings.jellyseerr_url))
+    // @ts-ignore
+    hostnameRef.current = {
+      value: removePortFromUrl(settingsCtx.settings.jellyseerr_url),
+    }
+
+    // port
+    setPort(getPortFromUrl(settingsCtx.settings.jellyseerr_url))
+    // @ts-ignore
+    portRef.current = {
+      value: getPortFromUrl(settingsCtx.settings.jellyseerr_url),
+    }
+  }, [settingsCtx])
+
+  const submit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    // if port not specified, but hostname is. Derive the port
+    if (!portRef.current?.value && hostnameRef.current?.value) {
+      const derivedPort = hostnameRef.current.value.includes('http://')
+        ? 80
+        : hostnameRef.current.value.includes('https://')
+          ? 443
+          : 80
+
+      if (derivedPort) {
+        setPort(derivedPort.toString())
+        // @ts-ignore
+        portRef.current = { value: derivedPort.toString() }
+      }
+    }
+
+    if (
+      hostnameRef.current?.value &&
+      apiKeyRef.current?.value &&
+      portRef.current?.value
+    ) {
+      const hostnameVal = hostnameRef.current.value.includes('http://')
+        ? hostnameRef.current.value
+        : hostnameRef.current.value.includes('https://')
+          ? hostnameRef.current.value
+          : portRef.current.value == '443'
+            ? 'https://' + hostnameRef.current.value
+            : 'http://' + hostnameRef.current.value
+
+      const payload = {
+        jellyseerr_url: addPortToUrl(hostnameVal, +portRef.current.value),
+        jellyseerr_api_key: apiKeyRef.current.value,
+      }
+      const resp: { code: 0 | 1; message: string } = await PostApiHandler(
+        '/settings',
+        {
+          ...settingsCtx.settings,
+          ...payload,
+        },
+      )
+      if (Boolean(resp.code)) {
+        settingsCtx.addSettings({
+          ...settingsCtx.settings,
+          ...payload,
+        })
+        setError(false)
+        setChanged(true)
+      } else setError(true)
+    } else {
+      setError(true)
+    }
+  }
+
+  const appTest = (result: { status: boolean; version: string }) => {
+    setTestbanner({ status: result.status, version: result.version })
+  }
+
+  return (
+    <div className="h-full w-full">
+      <div className="section h-full w-full">
+        <h3 className="heading">Jellyseerr Settings</h3>
+        <p className="description">Jellyseerr configuration</p>
+      </div>
+      {error ? (
+        <Alert type="warning" title="Not all fields contain values" />
+      ) : changed ? (
+        <Alert type="info" title="Settings successfully updated" />
+      ) : undefined}
+
+      {testBanner.version !== '0' ? (
+        testBanner.status ? (
+          <Alert
+            type="warning"
+            title={`Successfully connected to Jellyseerr (${testBanner.version})`}
+          />
+        ) : (
+          <Alert
+            type="error"
+            title="Connection failed! Double check your entries and make sure to Save Changes before you Test."
+          />
+        )
+      ) : undefined}
+
+      <div className="section">
+        <form onSubmit={submit}>
+          <div className="form-row">
+            <label htmlFor="hostname" className="text-label">
+              Hostname or IP
+            </label>
+            <div className="form-input">
+              <div className="form-input-field">
+                <input
+                  name="hostname"
+                  id="hostname"
+                  type="text"
+                  defaultValue={hostname}
+                  ref={hostnameRef}
+                  value={hostnameRef.current?.value}
+                  onChange={(e) =>
+                    handleSettingsInputChange(e, hostnameRef, setHostname)
+                  }
+                ></input>
+              </div>
+            </div>
+          </div>
+
+          <div className="form-row">
+            <label htmlFor="port" className="text-label">
+              Port
+            </label>
+            <div className="form-input">
+              <div className="form-input-field">
+                <input
+                  name="port"
+                  id="port"
+                  type="number"
+                  ref={portRef}
+                  value={portRef.current?.value}
+                  defaultValue={port}
+                  onChange={(e) =>
+                    handleSettingsInputChange(e, portRef, setPort)
+                  }
+                ></input>
+              </div>
+            </div>
+          </div>
+
+          <div className="form-row">
+            <label htmlFor="apikey" className="text-label">
+              Api key
+            </label>
+            <div className="form-input">
+              <div className="form-input-field">
+                <input
+                  name="apikey"
+                  id="apikey"
+                  type="password"
+                  ref={apiKeyRef}
+                  defaultValue={settingsCtx.settings.jellyseerr_api_key}
+                ></input>
+              </div>
+            </div>
+          </div>
+
+          <div className="actions mt-5 w-full">
+            <div className="flex w-full flex-wrap sm:flex-nowrap">
+              <span className="m-auto rounded-md shadow-sm sm:ml-3 sm:mr-auto">
+                <DocsButton page="Configuration/#jellyseerr" />
+              </span>
+              <div className="m-auto mt-3 flex xs:mt-0 sm:m-0 sm:justify-end">
+                <TestButton
+                  onClick={appTest}
+                  testUrl="/settings/test/jellyseerr"
+                />
+                <span className="ml-3 inline-flex rounded-md shadow-sm">
+                  <Button
+                    buttonType="primary"
+                    type="submit"
+                    // disabled={isSubmitting || !isValid}
+                  >
+                    <SaveIcon />
+                    <span>Save Changes</span>
+                  </Button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default JellyseerrSettings

--- a/ui/src/components/Settings/index.tsx
+++ b/ui/src/components/Settings/index.tsx
@@ -17,14 +17,19 @@ const SettingsWrapper: React.FC<{ children?: ReactNode }> = (props: {
       regex: /^\/settings(\/main)?$/,
     },
     {
+      text: 'Plex',
+      route: '/settings/plex',
+      regex: /^\/settings(\/plex)?$/,
+    },
+    {
       text: 'Overseerr',
       route: '/settings/overseerr',
       regex: /^\/settings(\/overseerr)?$/,
     },
     {
-      text: 'Plex',
-      route: '/settings/plex',
-      regex: /^\/settings(\/plex)?$/,
+      text: 'Jellyseerr',
+      route: '/settings/jellyseerr',
+      regex: /^\/settings(\/jellyseerr)?$/,
     },
     {
       text: 'Radarr',

--- a/ui/src/contexts/settings-context.tsx
+++ b/ui/src/contexts/settings-context.tsx
@@ -23,6 +23,8 @@ export interface ISettings {
   overseerr_api_key: string
   tautulli_url: string
   tautulli_api_key: string
+  jellyseerr_url: string
+  jellyseerr_api_key: string
   collection_handler_job_cron: string
   rules_handler_job_cron: string
 }

--- a/ui/src/pages/settings/jellyseerr/index.tsx
+++ b/ui/src/pages/settings/jellyseerr/index.tsx
@@ -1,0 +1,13 @@
+import { NextPage } from 'next'
+import SettingsWrapper from '../../../components/Settings'
+import JellyseerrSettings from '../../../components/Settings/Jellyseerr'
+
+const SettingsJellyseerr: NextPage = () => {
+  return (
+    <SettingsWrapper>
+      <JellyseerrSettings />
+    </SettingsWrapper>
+  )
+}
+
+export default SettingsJellyseerr


### PR DESCRIPTION
This is a complete copy of our existing Overseerr code as the APIs we use are functionally the same at the moment. The only feature I have not brought across is the 'Force reset Overseerr record' option, as availability sync should be used instead. If we have problems with this we can always introduce the option again.

Feature request: https://features.maintainerr.info/posts/69/jellyseerr