### PR TITLE
fix: Contracts not included in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,14 @@ COPY --from=builder --chmod=777 --chown=node:node /app/ui/.next/static ./ui/.nex
 COPY --from=builder --chmod=777 --chown=node:node /app/ui/public ./ui/public
 
 # Copy standalone server
-COPY --from=builder --chmod=777 --chown=node:node /app/server/dist ./server
+COPY --from=builder --chmod=777 --chown=node:node /app/server/dist ./server/dist
 COPY --from=builder --chmod=777 --chown=node:node /app/server/package.json ./server/package.json
 COPY --from=builder --chmod=777 --chown=node:node /app/server/node_modules ./server/node_modules
+
+# Copy packages/contracts
+COPY --from=builder --chmod=777 --chown=node:node /app/packages/contracts/dist ./packages/contracts/dist
+COPY --from=builder --chmod=777 --chown=node:node /app/packages/contracts/package.json ./packages/contracts/package.json
+COPY --from=builder --chmod=777 --chown=node:node /app/packages/contracts/node_modules ./packages/contracts/node_modules
 
 COPY docker/supervisord.conf /etc/supervisord.conf
 COPY --chmod=777 --chown=node:node docker/start.sh /opt/app/start.sh

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -4,7 +4,7 @@ logfile=/dev/null
 pidfile=/dev/null
 
 [program:server]
-command=npm run --prefix /opt/app/server start:release
+command=npm run --prefix /opt/app/server start
 autorestart=true
 startretries=100
 stdout_logfile=/dev/fd/1

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -28,6 +28,9 @@
     "format:check": "prettier --check --ignore-path .gitignore .",
     "check-types": "tsc --noEmit"
   },
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
     "eslint": "^9.19.0",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,6 @@
     "nest:build": "nest build",
     "swagger:build": "ts-node src/generate-metadata.ts",
     "start": "node dist/main",
-    "start:release": "node main",
     "lint": "eslint \"{src,test}/**/*.ts\" --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/server/src/app/config/typeOrmConfig.ts
+++ b/server/src/app/config/typeOrmConfig.ts
@@ -10,7 +10,7 @@ const ormConfig: TypeOrmModuleOptions = {
   subscribers: ['./**/*.subscriber{.ts,.js}'],
   migrations:
     process.env.NODE_ENV === 'production'
-      ? ['/opt/app/server/database/migrations/**/*{.js,.ts}']
+      ? ['/opt/app/server/dist/database/migrations/**/*{.js,.ts}']
       : ['./dist/database/migrations/**/*{.js,.ts}'],
   autoLoadEntities: true,
   migrationsRun: true,


### PR DESCRIPTION
I neglected to test the logging PR via a Docker build. We could do with a test in the pipeline to start the built image and validate the UI loads.