### PR TITLE
feat: Add rule & collection job status indicators

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Install dependencies
         run: yarn --immutable
 
+      - name: Build
+        run: yarn turbo build --filter="./packages/*"
+
       - name: Run tests
         run: yarn turbo test

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,17 @@
 {
-    // see
-    //  - https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions
-    "recommendations": [
-      // https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
-      "dbaeumer.vscode-eslint",
-  
-      // https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
-      "esbenp.prettier-vscode",
-  
-      "bradlc.vscode-tailwindcss"
-    ]
-  }
+  // see
+  //  - https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions
+  "recommendations": [
+    // https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
+    "dbaeumer.vscode-eslint",
+
+    // https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
+    "esbenp.prettier-vscode",
+
+    // https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss
+    "bradlc.vscode-tailwindcss",
+
+    // https://marketplace.visualstudio.com/items?itemName=orta.vscode-jest
+    "orta.vscode-jest"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,5 +46,12 @@
   },
   "search.exclude": {
     "**/.yarn": true
-  }
+  },
+  "jest.jestCommandLine": "yarn test",
+  "jest.virtualFolders": [
+    {
+      "name": "server",
+      "rootPath": "server"
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ services:
             target: /opt/data
         environment:
           - TZ=Europe/Brussels
-#      - DEBUG=true # uncomment to enable debug logs
 #      - BASE_PATH=/maintainerr # uncomment if you're serving maintainerr from a subdirectory
 #      - UI_HOSTNAME=:: # uncomment if you want to listen on IPv6 instead (default 0.0.0.0)
 #      - UI_PORT=6247 # uncomment to change the UI port (default 6246). Useful if you're on a network where the port is already in use

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "format": "turbo format",
     "format:check": "turbo format:check",
     "knip": "knip",
-    "check-types": "turbo check-types"
+    "check-types": "turbo check-types",
+    "test": "turbo test --",
+    "test:watch": "turbo test:watch"
   },
   "workspaces": [
     "ui",

--- a/packages/contracts/src/events/baseEvent.dto.ts
+++ b/packages/contracts/src/events/baseEvent.dto.ts
@@ -1,0 +1,11 @@
+import { MaintainerrEvent } from './maintainerrEvent'
+
+export class BaseEventDto {
+  type: MaintainerrEvent
+  time: Date
+
+  constructor(type: MaintainerrEvent) {
+    this.type = type
+    this.time = new Date()
+  }
+}

--- a/packages/contracts/src/events/collectionHandler.dto.ts
+++ b/packages/contracts/src/events/collectionHandler.dto.ts
@@ -10,7 +10,7 @@ export class CollectionHandlerStartedEventDto extends BaseEventDto {
   }
 }
 
-export class CollectionHandlerProgressEventDto extends BaseEventDto {
+export class CollectionHandlerProgressedEventDto extends BaseEventDto {
   totalCollections: number
   processingCollection:
     | {
@@ -24,7 +24,7 @@ export class CollectionHandlerProgressEventDto extends BaseEventDto {
   processedCollections: number
 
   constructor() {
-    super(MaintainerrEvent.CollectionHandler_Progress)
+    super(MaintainerrEvent.CollectionHandler_Progressed)
     this.totalCollections = 0
     this.processingCollection = undefined
     this.totalMediaToHandle = 0

--- a/packages/contracts/src/events/collectionHandler.dto.ts
+++ b/packages/contracts/src/events/collectionHandler.dto.ts
@@ -1,0 +1,43 @@
+import { BaseEventDto } from './baseEvent.dto'
+import { MaintainerrEvent } from './maintainerrEvent'
+
+export class CollectionHandlerStartedEventDto extends BaseEventDto {
+  message: string
+
+  constructor(message: string) {
+    super(MaintainerrEvent.CollectionHandler_Started)
+    this.message = message
+  }
+}
+
+export class CollectionHandlerProgressEventDto extends BaseEventDto {
+  totalCollections: number
+  processingCollection:
+    | {
+        processedMedias: number
+        name: string
+        totalMedias: number
+      }
+    | undefined
+  totalMediaToHandle: number
+  processedMedias: number
+  processedCollections: number
+
+  constructor() {
+    super(MaintainerrEvent.CollectionHandler_Progress)
+    this.totalCollections = 0
+    this.processingCollection = undefined
+    this.totalMediaToHandle = 0
+    this.processedMedias = 0
+    this.processedCollections = 0
+  }
+}
+
+export class CollectionHandlerFinishedEventDto extends BaseEventDto {
+  message: string
+
+  constructor(message: string) {
+    super(MaintainerrEvent.CollectionHandler_Finished)
+    this.message = message
+  }
+}

--- a/packages/contracts/src/events/index.ts
+++ b/packages/contracts/src/events/index.ts
@@ -1,0 +1,4 @@
+export * from './baseEvent.dto'
+export * from './collectionHandler.dto'
+export * from './maintainerrEvent'
+export * from './ruleHandler.dto'

--- a/packages/contracts/src/events/maintainerrEvent.ts
+++ b/packages/contracts/src/events/maintainerrEvent.ts
@@ -1,0 +1,8 @@
+export enum MaintainerrEvent {
+  RuleHandler_Started = 'rule_handler.started',
+  RuleHandler_Progress = 'rule_handler.progress',
+  RuleHandler_Finished = 'rule_handler.finished',
+  CollectionHandler_Started = 'collection_handler.started',
+  CollectionHandler_Progress = 'collection_handler.progress',
+  CollectionHandler_Finished = 'collection_handler.finished',
+}

--- a/packages/contracts/src/events/maintainerrEvent.ts
+++ b/packages/contracts/src/events/maintainerrEvent.ts
@@ -1,8 +1,8 @@
 export enum MaintainerrEvent {
   RuleHandler_Started = 'rule_handler.started',
-  RuleHandler_Progress = 'rule_handler.progress',
+  RuleHandler_Progressed = 'rule_handler.progressed',
   RuleHandler_Finished = 'rule_handler.finished',
   CollectionHandler_Started = 'collection_handler.started',
-  CollectionHandler_Progress = 'collection_handler.progress',
+  CollectionHandler_Progressed = 'collection_handler.progressed',
   CollectionHandler_Finished = 'collection_handler.finished',
 }

--- a/packages/contracts/src/events/ruleHandler.dto.ts
+++ b/packages/contracts/src/events/ruleHandler.dto.ts
@@ -10,7 +10,7 @@ export class RuleHandlerStartedEventDto extends BaseEventDto {
   }
 }
 
-export class RuleHandlerProgressEventDto extends BaseEventDto {
+export class RuleHandlerProgressedEventDto extends BaseEventDto {
   totalRuleGroups: number
   totalEvaluations: number
   processingRuleGroup:
@@ -24,7 +24,7 @@ export class RuleHandlerProgressEventDto extends BaseEventDto {
   processedEvaluations: number
 
   constructor() {
-    super(MaintainerrEvent.RuleHandler_Progress)
+    super(MaintainerrEvent.RuleHandler_Progressed)
     this.totalRuleGroups = 0
     this.processingRuleGroup = undefined
     this.totalEvaluations = 0

--- a/packages/contracts/src/events/ruleHandler.dto.ts
+++ b/packages/contracts/src/events/ruleHandler.dto.ts
@@ -1,0 +1,42 @@
+import { BaseEventDto } from './baseEvent.dto'
+import { MaintainerrEvent } from './maintainerrEvent'
+
+export class RuleHandlerStartedEventDto extends BaseEventDto {
+  message: string
+
+  constructor(message: string) {
+    super(MaintainerrEvent.RuleHandler_Started)
+    this.message = message
+  }
+}
+
+export class RuleHandlerProgressEventDto extends BaseEventDto {
+  totalRuleGroups: number
+  totalEvaluations: number
+  processingRuleGroup:
+    | {
+        number: number
+        name: string
+        processedEvaluations: number
+        totalEvaluations: number
+      }
+    | undefined
+  processedEvaluations: number
+
+  constructor() {
+    super(MaintainerrEvent.RuleHandler_Progress)
+    this.totalRuleGroups = 0
+    this.processingRuleGroup = undefined
+    this.totalEvaluations = 0
+    this.processedEvaluations = 0
+  }
+}
+
+export class RuleHandlerFinishedEventDto extends BaseEventDto {
+  message: string
+
+  constructor(message: string) {
+    super(MaintainerrEvent.RuleHandler_Finished)
+    this.message = message
+  }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,2 +1,4 @@
 export * from './app'
+export * from './events'
 export * from './settings/logs'
+export * from './tasks'

--- a/packages/contracts/src/tasks/index.ts
+++ b/packages/contracts/src/tasks/index.ts
@@ -1,0 +1,1 @@
+export * from './taskStatus.dto'

--- a/packages/contracts/src/tasks/taskStatus.dto.ts
+++ b/packages/contracts/src/tasks/taskStatus.dto.ts
@@ -1,0 +1,11 @@
+export class TaskStatusDto {
+  time: Date
+  running: boolean
+  runningSince?: Date
+
+  constructor(time: Date, running: boolean, runningSince?: Date) {
+    this.time = time
+    this.running = running
+    this.runningSince = runningSince
+  }
+}

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -16,7 +16,7 @@ lerna-debug.log*
 .DS_Store
 
 # Tests
-/coverage
+coverage
 /.nyc_output
 
 # IDEs and editors

--- a/server/package.json
+++ b/server/package.json
@@ -55,9 +55,13 @@
     "@automock/jest": "^2.1.0",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.23.0",
+    "@faker-js/faker": "^9.6.0",
     "@nestjs/cli": "^11.0.5",
     "@nestjs/schematics": "^11.0.2",
     "@nestjs/testing": "^11.0.12",
+    "@suites/di.nestjs": "^3.0.1",
+    "@suites/doubles.jest": "^3.0.1",
+    "@suites/unit": "^3.0.1",
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.15",
     "@types/mime-types": "^2",
@@ -89,6 +93,10 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "./coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "preset": "ts-jest",
+    "setupFilesAfterEnv": [
+      "<rootDir>/../test/jest.setup.ts"
+    ]
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -87,14 +87,13 @@
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.ts$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s"
+      "**/*.ts"
     ],
     "coverageDirectory": "./coverage",
     "testEnvironment": "node",
-    "preset": "ts-jest",
     "setupFilesAfterEnv": [
       "<rootDir>/../test/jest.setup.ts"
     ]

--- a/server/src/app/app.module.ts
+++ b/server/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { TautulliApiModule } from '../modules/api/tautulli-api/tautulli-api.modu
 import { TautulliApiService } from '../modules/api/tautulli-api/tautulli-api.service';
 import { TmdbApiModule } from '../modules/api/tmdb-api/tmdb.module';
 import { CollectionsModule } from '../modules/collections/collections.module';
+import { EventsModule } from '../modules/events/events.module';
 import { LogsModule } from '../modules/logging/logs.module';
 import { RulesModule } from '../modules/rules/rules.module';
 import { SettingsModule } from '../modules/settings/settings.module';
@@ -26,7 +27,9 @@ import ormConfig from './config/typeOrmConfig';
 @Module({
   imports: [
     TypeOrmModule.forRoot(ormConfig),
-    EventEmitterModule.forRoot(),
+    EventEmitterModule.forRoot({
+      wildcard: true,
+    }),
     LogsModule,
     SettingsModule,
     PlexApiModule,
@@ -38,6 +41,7 @@ import ormConfig from './config/typeOrmConfig';
     JellyseerrApiModule,
     RulesModule,
     CollectionsModule,
+    EventsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/server/src/modules/actions/actions.module.ts
+++ b/server/src/modules/actions/actions.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { PlexApiModule } from '../api/plex-api/plex-api.module';
+import { ServarrApiModule } from '../api/servarr-api/servarr-api.module';
+import { TmdbApiModule } from '../api/tmdb-api/tmdb.module';
+import { MediaIdFinder } from './media-id-finder';
+import { RadarrActionHandler } from './radarr-action-handler';
+import { SonarrActionHandler } from './sonarr-action-handler';
+
+@Module({
+  imports: [PlexApiModule, TmdbApiModule, ServarrApiModule],
+  providers: [RadarrActionHandler, SonarrActionHandler, MediaIdFinder],
+  exports: [RadarrActionHandler, SonarrActionHandler],
+  controllers: [],
+})
+export class ActionsModule {}

--- a/server/src/modules/actions/media-id-finder.ts
+++ b/server/src/modules/actions/media-id-finder.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { TmdbIdService } from '../api/tmdb-api/tmdb-id.service';
+import { TmdbApiService } from '../api/tmdb-api/tmdb.service';
+
+@Injectable()
+export class MediaIdFinder {
+  constructor(
+    private plexApi: PlexApiService,
+    private tmdbApi: TmdbApiService,
+    private tmdbIdHelper: TmdbIdService,
+  ) {}
+
+  public async findTvdbId(plexId: string | number, tmdbId?: number | null) {
+    let tvdbid = undefined;
+    if (!tmdbId && plexId) {
+      tmdbId = (
+        await this.tmdbIdHelper.getTmdbIdFromPlexRatingKey(plexId.toString())
+      )?.id;
+    }
+
+    const tmdbShow = tmdbId
+      ? await this.tmdbApi.getTvShow({ tvId: tmdbId })
+      : undefined;
+
+    if (!tmdbShow?.external_ids?.tvdb_id) {
+      let plexData = await this.plexApi.getMetadata(plexId.toString());
+      // fetch correct record for seasons & episodes
+      plexData = plexData.grandparentRatingKey
+        ? await this.plexApi.getMetadata(
+            plexData.grandparentRatingKey.toString(),
+          )
+        : plexData.parentRatingKey
+          ? await this.plexApi.getMetadata(plexData.parentRatingKey.toString())
+          : plexData;
+
+      const tvdbidPlex = plexData?.Guid?.find((el) => el.id.includes('tvdb'));
+      if (tvdbidPlex) {
+        tvdbid = tvdbidPlex.id.split('tvdb://')[1];
+      }
+    } else {
+      tvdbid = tmdbShow.external_ids.tvdb_id;
+    }
+
+    return tvdbid;
+  }
+}

--- a/server/src/modules/actions/radarr-action-handler.spec.ts
+++ b/server/src/modules/actions/radarr-action-handler.spec.ts
@@ -1,0 +1,164 @@
+import { Mocked } from '@suites/doubles.jest';
+import { TestBed } from '@suites/unit';
+import {
+  createCollection,
+  createCollectionMedia,
+  createRadarrMovie,
+} from '../../utils/testing/data';
+import { EPlexDataType } from '../api/plex-api/enums/plex-data-type-enum';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { RadarrApi } from '../api/servarr-api/helpers/radarr.helper';
+import { ServarrService } from '../api/servarr-api/servarr.service';
+import { TmdbIdService } from '../api/tmdb-api/tmdb-id.service';
+import { ServarrAction } from '../collections/interfaces/collection.interface';
+import { RadarrActionHandler } from './radarr-action-handler';
+
+describe('RadarrActionHandler', () => {
+  let radarrActionHandler: RadarrActionHandler;
+  let plexApi: Mocked<PlexApiService>;
+  let servarrService: Mocked<ServarrService>;
+  let tmdbIdService: Mocked<TmdbIdService>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(RadarrActionHandler).compile();
+
+    radarrActionHandler = unit;
+    plexApi = unitRef.get(PlexApiService);
+    servarrService = unitRef.get(ServarrService);
+    tmdbIdService = unitRef.get(TmdbIdService);
+  });
+
+  it('should do nothing when tmdbid failed lookup', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      radarrSettingsId: 1,
+      type: EPlexDataType.MOVIES,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'movie', {
+      tmdbId: undefined,
+    });
+
+    tmdbIdService.getTmdbIdFromPlexRatingKey.mockResolvedValue(undefined);
+
+    const mockedRadarrApi = mockRadarrApi();
+
+    await radarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(tmdbIdService.getTmdbIdFromPlexRatingKey).toHaveBeenCalled();
+    validateNoRadarrActionsTaken(mockedRadarrApi);
+  });
+
+  it('should do nothing when movie cannot be found and action is UNMONITOR', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR,
+      radarrSettingsId: 1,
+      type: EPlexDataType.MOVIES,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'movie', {
+      tmdbId: 1,
+    });
+
+    const mockedRadarrApi = mockRadarrApi();
+    jest
+      .spyOn(mockedRadarrApi, 'getMovieByTmdbId')
+      .mockResolvedValue(undefined);
+
+    await radarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mockedRadarrApi.getMovieByTmdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    validateNoRadarrActionsTaken(mockedRadarrApi);
+  });
+
+  it.each([
+    { action: ServarrAction.DELETE, title: 'DELETE' },
+    {
+      action: ServarrAction.UNMONITOR_DELETE_EXISTING,
+      title: 'UNMONITOR_DELETE_EXISTING',
+    },
+  ])(
+    'should delete movie when action is $title',
+    async ({ action }: { action: ServarrAction }) => {
+      const collection = createCollection({
+        arrAction: action,
+        radarrSettingsId: 1,
+        type: EPlexDataType.MOVIES,
+      });
+      const collectionMedia = createCollectionMedia(collection, 'movie', {
+        tmdbId: 1,
+      });
+
+      const mockedRadarrApi = mockRadarrApi();
+      jest
+        .spyOn(mockedRadarrApi, 'getMovieByTmdbId')
+        .mockResolvedValue(createRadarrMovie({ id: 5 }));
+
+      await radarrActionHandler.handleAction(collection, collectionMedia);
+
+      expect(mockedRadarrApi.deleteMovie).toHaveBeenCalledWith(
+        5,
+        true,
+        collection.listExclusions,
+      );
+      expect(mockedRadarrApi.unmonitorMovie).not.toHaveBeenCalled();
+    },
+  );
+
+  it('should unmonitor movie when action is UNMONITOR', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR,
+      radarrSettingsId: 1,
+      type: EPlexDataType.MOVIES,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'movie', {
+      tmdbId: 1,
+    });
+
+    const mockedRadarrApi = mockRadarrApi();
+    jest
+      .spyOn(mockedRadarrApi, 'getMovieByTmdbId')
+      .mockResolvedValue(createRadarrMovie({ id: 5 }));
+
+    await radarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mockedRadarrApi.unmonitorMovie).toHaveBeenCalledWith(5, false);
+    expect(mockedRadarrApi.deleteMovie).not.toHaveBeenCalled();
+  });
+
+  it('should unmonitor and delete movie when action is UNMONITOR_DELETE_ALL', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_DELETE_ALL,
+      radarrSettingsId: 1,
+      type: EPlexDataType.MOVIES,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'movie', {
+      tmdbId: 1,
+    });
+
+    const mockedRadarrApi = mockRadarrApi();
+    jest
+      .spyOn(mockedRadarrApi, 'getMovieByTmdbId')
+      .mockResolvedValue(createRadarrMovie({ id: 5 }));
+
+    await radarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mockedRadarrApi.unmonitorMovie).toHaveBeenCalledWith(5, true);
+    expect(mockedRadarrApi.deleteMovie).not.toHaveBeenCalled();
+  });
+
+  const validateNoRadarrActionsTaken = (radarrApi: RadarrApi) => {
+    expect(radarrApi.unmonitorMovie).not.toHaveBeenCalled();
+    expect(radarrApi.deleteMovie).not.toHaveBeenCalled();
+  };
+
+  const mockRadarrApi = () => {
+    const mockedRadarrApi = new RadarrApi({} as any);
+    jest.spyOn(mockedRadarrApi, 'deleteMovie').mockImplementation(jest.fn());
+    jest.spyOn(mockedRadarrApi, 'unmonitorMovie').mockImplementation(jest.fn());
+
+    servarrService.getRadarrApiClient.mockResolvedValue(mockedRadarrApi);
+
+    return mockedRadarrApi;
+  };
+});

--- a/server/src/modules/actions/radarr-action-handler.spec.ts
+++ b/server/src/modules/actions/radarr-action-handler.spec.ts
@@ -4,7 +4,7 @@ import {
   createCollection,
   createCollectionMedia,
   createRadarrMovie,
-} from '../../utils/testing/data';
+} from '../../../test/utils/data';
 import { EPlexDataType } from '../api/plex-api/enums/plex-data-type-enum';
 import { PlexApiService } from '../api/plex-api/plex-api.service';
 import { RadarrApi } from '../api/servarr-api/helpers/radarr.helper';

--- a/server/src/modules/actions/radarr-action-handler.ts
+++ b/server/src/modules/actions/radarr-action-handler.ts
@@ -1,0 +1,76 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { ServarrService } from '../api/servarr-api/servarr.service';
+import { TmdbIdService } from '../api/tmdb-api/tmdb-id.service';
+import { Collection } from '../collections/entities/collection.entities';
+import { CollectionMedia } from '../collections/entities/collection_media.entities';
+import { ServarrAction } from '../collections/interfaces/collection.interface';
+
+@Injectable()
+export class RadarrActionHandler {
+  private readonly logger = new Logger(RadarrActionHandler.name);
+
+  constructor(
+    private readonly servarrApi: ServarrService,
+    private readonly plexApi: PlexApiService,
+    private readonly tmdbIdService: TmdbIdService,
+  ) {}
+
+  public async handleAction(
+    collection: Collection,
+    media: CollectionMedia,
+  ): Promise<void> {
+    const radarrApiClient = await this.servarrApi.getRadarrApiClient(
+      collection.radarrSettingsId,
+    );
+
+    // find tmdbid
+    const tmdbid = media.tmdbId
+      ? media.tmdbId
+      : (
+          await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
+            media.plexId.toString(),
+          )
+        )?.id;
+
+    if (tmdbid) {
+      const radarrMedia = await radarrApiClient.getMovieByTmdbId(tmdbid);
+      if (radarrMedia && radarrMedia.id) {
+        switch (collection.arrAction) {
+          case ServarrAction.DELETE:
+          case ServarrAction.UNMONITOR_DELETE_EXISTING:
+            await radarrApiClient.deleteMovie(
+              radarrMedia.id,
+              true,
+              collection.listExclusions,
+            );
+            this.logger.log('Removed movie from filesystem & Radarr');
+            break;
+          case ServarrAction.UNMONITOR:
+            await radarrApiClient.unmonitorMovie(radarrMedia.id, false);
+            this.logger.log('Unmonitored movie in Radarr');
+            break;
+          case ServarrAction.UNMONITOR_DELETE_ALL:
+            await radarrApiClient.unmonitorMovie(radarrMedia.id, true);
+            this.logger.log('Unmonitored movie in Radarr & removed files');
+            break;
+        }
+      } else {
+        if (collection.arrAction !== ServarrAction.UNMONITOR) {
+          this.logger.log(
+            `Couldn't find movie with tmdb id ${tmdbid} in Radarr, so no Radarr action was taken for movie with Plex ID ${media.plexId}. Attempting to remove from the filesystem via Plex.`,
+          );
+          await this.plexApi.deleteMediaFromDisk(media.plexId.toString());
+        } else {
+          this.logger.log(
+            `Radarr unmonitor action was not possible, couldn't find movie with tmdb id ${tmdbid} in Radarr. No action was taken for movie with Plex ID ${media.plexId}`,
+          );
+        }
+      }
+    } else {
+      this.logger.log(
+        `Couldn't find correct tmdb id. No action taken for movie with Plex ID: ${media.plexId}. Please check this movie manually`,
+      );
+    }
+  }
+}

--- a/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -4,7 +4,7 @@ import {
   createCollection,
   createCollectionMediaWithPlexData,
   createSonarrSeries,
-} from '../../utils/testing/data';
+} from '../../../test/utils/data';
 import { EPlexDataType } from '../api/plex-api/enums/plex-data-type-enum';
 import { PlexApiService } from '../api/plex-api/plex-api.service';
 import { SonarrApi } from '../api/servarr-api/helpers/sonarr.helper';

--- a/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -40,7 +40,7 @@ describe('SonarrActionHandler', () => {
       title: 'EPISODES',
     },
   ])(
-    'should do nothing for $type when Show tmdbid failed lookup',
+    'should do nothing for $title when Show tmdbid failed lookup',
     async ({ type }: { type: EPlexDataType }) => {
       const collection = createCollection({
         arrAction: ServarrAction.DELETE,

--- a/server/src/modules/actions/sonarr-action-handler.spec.ts
+++ b/server/src/modules/actions/sonarr-action-handler.spec.ts
@@ -1,0 +1,684 @@
+import { Mocked } from '@suites/doubles.jest';
+import { TestBed } from '@suites/unit';
+import {
+  createCollection,
+  createCollectionMediaWithPlexData,
+  createSonarrSeries,
+} from '../../utils/testing/data';
+import { EPlexDataType } from '../api/plex-api/enums/plex-data-type-enum';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { SonarrApi } from '../api/servarr-api/helpers/sonarr.helper';
+import { ServarrService } from '../api/servarr-api/servarr.service';
+import { ServarrAction } from '../collections/interfaces/collection.interface';
+import { MediaIdFinder } from './media-id-finder';
+import { SonarrActionHandler } from './sonarr-action-handler';
+
+describe('SonarrActionHandler', () => {
+  let sonarrActionHandler: SonarrActionHandler;
+  let plexApi: Mocked<PlexApiService>;
+  let servarrService: Mocked<ServarrService>;
+  let mediaIdFinder: Mocked<MediaIdFinder>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(SonarrActionHandler).compile();
+
+    sonarrActionHandler = unit;
+    plexApi = unitRef.get(PlexApiService);
+    servarrService = unitRef.get(ServarrService);
+    mediaIdFinder = unitRef.get(MediaIdFinder);
+  });
+
+  it.each([
+    { type: EPlexDataType.SEASONS, title: 'SEASONS' },
+    {
+      type: EPlexDataType.SHOWS,
+      title: 'SHOWS',
+    },
+    {
+      type: EPlexDataType.EPISODES,
+      title: 'EPISODES',
+    },
+  ])(
+    'should do nothing for $type when Show tmdbid failed lookup',
+    async ({ type }: { type: EPlexDataType }) => {
+      const collection = createCollection({
+        arrAction: ServarrAction.DELETE,
+        sonarrSettingsId: 1,
+        type: type,
+      });
+      const collectionMedia = createCollectionMediaWithPlexData(
+        collection,
+        'show',
+        {
+          tmdbId: 1,
+        },
+      );
+
+      plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+      const mockedSonarrApi = mockSonarrApi();
+      jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId');
+
+      mediaIdFinder.findTvdbId.mockResolvedValue(undefined);
+
+      await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+      expect(mockedSonarrApi.getSeriesByTvdbId).not.toHaveBeenCalled();
+      expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+      expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+      validateNoSonarrActionsTaken(mockedSonarrApi);
+    },
+  );
+
+  it.each([
+    { type: EPlexDataType.SEASONS, title: 'SEASONS' },
+    {
+      type: EPlexDataType.SHOWS,
+      title: 'SHOWS',
+    },
+    {
+      type: EPlexDataType.EPISODES,
+      title: 'EPISODES',
+    },
+  ])(
+    'should do nothing for $title if not found in Sonarr and action is UNMONITOR',
+    async ({ type }: { type: EPlexDataType }) => {
+      const collection = createCollection({
+        arrAction: ServarrAction.UNMONITOR,
+        sonarrSettingsId: 1,
+        type: type,
+      });
+      const collectionMedia = createCollectionMediaWithPlexData(
+        collection,
+        'show',
+        {
+          tmdbId: 1,
+        },
+      );
+
+      plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+      const mockedSonarrApi = mockSonarrApi();
+      jest
+        .spyOn(mockedSonarrApi, 'getSeriesByTvdbId')
+        .mockResolvedValue(undefined);
+
+      mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+      await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+      expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+      expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+      expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+      validateNoSonarrActionsTaken(mockedSonarrApi);
+    },
+  );
+
+  it.each([
+    {
+      type: EPlexDataType.SEASONS,
+      title: 'SEASONS',
+      action: ServarrAction.DELETE,
+    },
+    {
+      type: EPlexDataType.SEASONS,
+      title: 'SEASONS',
+      action: ServarrAction.UNMONITOR_DELETE_ALL,
+    },
+    {
+      type: EPlexDataType.SEASONS,
+      title: 'SEASONS',
+      action: ServarrAction.UNMONITOR_DELETE_EXISTING,
+    },
+    {
+      type: EPlexDataType.SHOWS,
+      title: 'SHOWS',
+      action: ServarrAction.DELETE,
+    },
+    {
+      type: EPlexDataType.SHOWS,
+      title: 'SHOWS',
+      action: ServarrAction.UNMONITOR_DELETE_ALL,
+    },
+    {
+      type: EPlexDataType.SHOWS,
+      title: 'SHOWS',
+      action: ServarrAction.UNMONITOR_DELETE_EXISTING,
+    },
+    {
+      type: EPlexDataType.EPISODES,
+      title: 'EPISODES',
+      action: ServarrAction.DELETE,
+    },
+    {
+      type: EPlexDataType.EPISODES,
+      title: 'EPISODES',
+      action: ServarrAction.UNMONITOR_DELETE_ALL,
+    },
+    {
+      type: EPlexDataType.EPISODES,
+      title: 'EPISODES',
+      action: ServarrAction.UNMONITOR_DELETE_EXISTING,
+    },
+  ])(
+    'should delete $title in Plex if not found in Sonarr and action is $action',
+    async ({
+      type,
+      action,
+    }: {
+      type: EPlexDataType;
+      action: ServarrAction;
+    }) => {
+      const collection = createCollection({
+        arrAction: action,
+        sonarrSettingsId: 1,
+        type: type,
+      });
+      const collectionMedia = createCollectionMediaWithPlexData(
+        collection,
+        'show',
+        {
+          tmdbId: 1,
+        },
+      );
+
+      plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+      const mockedSonarrApi = mockSonarrApi();
+      jest
+        .spyOn(mockedSonarrApi, 'getSeriesByTvdbId')
+        .mockResolvedValue(undefined);
+
+      mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+      await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+      expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+      expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+      expect(plexApi.deleteMediaFromDisk).toHaveBeenCalled();
+      validateNoSonarrActionsTaken(mockedSonarrApi);
+    },
+  );
+
+  it('should unmonitor season and delete episodes when type SEASONS and action DELETE', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.SEASONS,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'season',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.UnmonitorDeleteEpisodes).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.delete).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.unmonitorSeasons).toHaveBeenCalledWith(
+      series.id,
+      collectionMedia.plexData.index,
+      true,
+    );
+  });
+
+  it('should unmonitor and delete episode when type EPISODES and action DELETE', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.EPISODES,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'episode',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.unmonitorSeasons).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.delete).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.UnmonitorDeleteEpisodes).toHaveBeenCalledWith(
+      series.id,
+      collectionMedia.plexData.parentIndex,
+      [collectionMedia.plexData.index],
+      true,
+    );
+  });
+
+  it('should delete show when type SHOWS and action DELETE', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.SHOWS,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'show',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.unmonitorSeasons).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.UnmonitorDeleteEpisodes).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.delete).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.deleteShow).toHaveBeenCalledWith(
+      series.id,
+      true,
+      collection.listExclusions,
+    );
+  });
+
+  it('should unmonitor season and episodes when type SEASONS and action UNMONITOR', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.SEASONS,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'season',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.UnmonitorDeleteEpisodes).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.delete).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.unmonitorSeasons).toHaveBeenCalledWith(
+      series.id,
+      collectionMedia.plexData.index,
+      false,
+    );
+  });
+
+  it('should unmonitor episode when type EPISODES and action UNMONITOR', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.EPISODES,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'episode',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.unmonitorSeasons).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.delete).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.UnmonitorDeleteEpisodes).toHaveBeenCalledWith(
+      series.id,
+      collectionMedia.plexData.parentIndex,
+      [collectionMedia.plexData.index],
+      false,
+    );
+  });
+
+  it('should unmonitor show, seasons and episodes when type SHOWS and action UNMONITOR', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.SHOWS,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'show',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'updateSeries').mockResolvedValue();
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.UnmonitorDeleteEpisodes).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.delete).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.unmonitorSeasons).toHaveBeenCalledWith(
+      series.id,
+      'all',
+      false,
+    );
+    expect(mockedSonarrApi.updateSeries).toHaveBeenCalledWith({
+      ...series,
+      monitored: false,
+    });
+  });
+
+  it('should do nothing for season when type SEASONS and action UNMONITOR_DELETE_ALL', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_DELETE_ALL,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.SEASONS,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'season',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    validateNoSonarrActionsTaken(mockedSonarrApi);
+  });
+
+  it('should do nothing for episode type EPISODES and action UNMONITOR_DELETE_ALL', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_DELETE_ALL,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.EPISODES,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'episode',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    validateNoSonarrActionsTaken(mockedSonarrApi);
+  });
+
+  it('should unmonitor show, seasons and episodes and delete all files when type SHOWS and action UNMONITOR_DELETE_ALL', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_DELETE_ALL,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.SHOWS,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'show',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'updateSeries').mockResolvedValue();
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.UnmonitorDeleteEpisodes).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.delete).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.unmonitorSeasons).toHaveBeenCalledWith(
+      series.id,
+      'all',
+      true,
+    );
+    expect(mockedSonarrApi.updateSeries).toHaveBeenCalledWith({
+      ...series,
+      monitored: false,
+    });
+  });
+
+  it('should ummonitor and delete existing episodes, leaving season monitored, when type SEASONS and action UNMONITOR_DELETE_EXISTING', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_DELETE_EXISTING,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.SEASONS,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'season',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.UnmonitorDeleteEpisodes).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.delete).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.unmonitorSeasons).toHaveBeenCalledWith(
+      series.id,
+      collectionMedia.plexData.index,
+      true,
+      true,
+    );
+  });
+
+  it('should do nothing for episode when type EPISODES and action UNMONITOR_DELETE_EXISTING', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_DELETE_EXISTING,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.EPISODES,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'episode',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    validateNoSonarrActionsTaken(mockedSonarrApi);
+  });
+
+  it('should unmonitor show, unmonitor and delete existing episodes and leave season monitored, when type SHOWS and action UNMONITOR_DELETE_EXISTING', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.UNMONITOR_DELETE_EXISTING,
+      sonarrSettingsId: 1,
+      type: EPlexDataType.SHOWS,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'show',
+      {
+        tmdbId: 1,
+      },
+    );
+
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    const series = createSonarrSeries();
+
+    const mockedSonarrApi = mockSonarrApi();
+    jest.spyOn(mockedSonarrApi, 'getSeriesByTvdbId').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'unmonitorSeasons').mockResolvedValue(series);
+    jest.spyOn(mockedSonarrApi, 'updateSeries').mockResolvedValue();
+
+    mediaIdFinder.findTvdbId.mockResolvedValue(1);
+
+    await sonarrActionHandler.handleAction(collection, collectionMedia);
+
+    expect(mediaIdFinder.findTvdbId).toHaveBeenCalled();
+    expect(mockedSonarrApi.getSeriesByTvdbId).toHaveBeenCalled();
+    expect(plexApi.deleteMediaFromDisk).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.deleteShow).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.UnmonitorDeleteEpisodes).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.delete).not.toHaveBeenCalled();
+    expect(mockedSonarrApi.unmonitorSeasons).toHaveBeenCalledWith(
+      series.id,
+      'existing',
+      true,
+    );
+    expect(mockedSonarrApi.updateSeries).toHaveBeenCalledWith({
+      ...series,
+      monitored: false,
+    });
+  });
+
+  const validateNoSonarrActionsTaken = (sonarrApi: SonarrApi) => {
+    expect(sonarrApi.unmonitorSeasons).not.toHaveBeenCalled();
+    expect(sonarrApi.UnmonitorDeleteEpisodes).not.toHaveBeenCalled();
+    expect(sonarrApi.deleteShow).not.toHaveBeenCalled();
+    expect(sonarrApi.delete).not.toHaveBeenCalled();
+  };
+
+  const mockSonarrApi = () => {
+    const mockedSonarrApi = new SonarrApi({} as any);
+    jest
+      .spyOn(mockedSonarrApi, 'unmonitorSeasons')
+      .mockImplementation(jest.fn());
+    jest
+      .spyOn(mockedSonarrApi, 'UnmonitorDeleteEpisodes')
+      .mockImplementation(jest.fn());
+    jest.spyOn(mockedSonarrApi, 'deleteShow').mockImplementation(jest.fn());
+    jest.spyOn(mockedSonarrApi, 'delete').mockImplementation(jest.fn());
+    servarrService.getSonarrApiClient.mockResolvedValue(mockedSonarrApi);
+
+    return mockedSonarrApi;
+  };
+});

--- a/server/src/modules/actions/sonarr-action-handler.ts
+++ b/server/src/modules/actions/sonarr-action-handler.ts
@@ -1,0 +1,243 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { EPlexDataType } from '../api/plex-api/enums/plex-data-type-enum';
+import { PlexMetadata } from '../api/plex-api/interfaces/media.interface';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { ServarrService } from '../api/servarr-api/servarr.service';
+import { TmdbIdService } from '../api/tmdb-api/tmdb-id.service';
+import { Collection } from '../collections/entities/collection.entities';
+import { CollectionMedia } from '../collections/entities/collection_media.entities';
+import { ServarrAction } from '../collections/interfaces/collection.interface';
+import { MediaIdFinder } from './media-id-finder';
+
+@Injectable()
+export class SonarrActionHandler {
+  private readonly logger = new Logger(SonarrActionHandler.name);
+
+  constructor(
+    private readonly servarrApi: ServarrService,
+    private readonly plexApi: PlexApiService,
+    private readonly tmdbIdService: TmdbIdService,
+    private readonly mediaIdFinder: MediaIdFinder,
+  ) {}
+
+  public async handleAction(
+    collection: Collection,
+    media: CollectionMedia,
+  ): Promise<void> {
+    const sonarrApiClient = await this.servarrApi.getSonarrApiClient(
+      collection.sonarrSettingsId,
+    );
+
+    let plexData: PlexMetadata = undefined;
+
+    // get the tvdb id
+    let tvdbId = undefined;
+    switch (collection.type) {
+      case EPlexDataType.SEASONS:
+        plexData = await this.plexApi.getMetadata(media.plexId.toString());
+        tvdbId = await this.mediaIdFinder.findTvdbId(
+          plexData.parentRatingKey,
+          media.tmdbId,
+        );
+        media.tmdbId = media.tmdbId
+          ? media.tmdbId
+          : (
+              await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
+                plexData.parentRatingKey,
+              )
+            )?.id;
+        break;
+      case EPlexDataType.EPISODES:
+        plexData = await this.plexApi.getMetadata(media.plexId.toString());
+        tvdbId = await this.mediaIdFinder.findTvdbId(
+          plexData.grandparentRatingKey,
+          media.tmdbId,
+        );
+        media.tmdbId = media.tmdbId
+          ? media.tmdbId
+          : (
+              await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
+                plexData.grandparentRatingKey.toString(),
+              )
+            )?.id;
+        break;
+      default:
+        tvdbId = await this.mediaIdFinder.findTvdbId(
+          media.plexId,
+          media.tmdbId,
+        );
+        media.tmdbId = media.tmdbId
+          ? media.tmdbId
+          : (
+              await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
+                media.plexId.toString(),
+              )
+            )?.id;
+        break;
+    }
+
+    if (!tvdbId) {
+      this.logger.log(
+        `Couldn't find correct tvdb id. No action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}. Please check this show manually`,
+      );
+      return;
+    }
+
+    let sonarrMedia = await sonarrApiClient.getSeriesByTvdbId(tvdbId);
+
+    if (!sonarrMedia?.id) {
+      if (collection.arrAction !== ServarrAction.UNMONITOR) {
+        this.logger.log(
+          `Couldn't find correct tvdb id. No Sonarr action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}. Attempting to remove from the filesystem via Plex.`,
+        );
+        this.plexApi.deleteMediaFromDisk(media.plexId.toString());
+      } else {
+        this.logger.log(
+          `Couldn't find correct tvdb id. No unmonitor action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}`,
+        );
+      }
+      return;
+    }
+
+    switch (collection.arrAction) {
+      case ServarrAction.DELETE:
+        switch (collection.type) {
+          case EPlexDataType.SEASONS:
+            sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+              sonarrMedia.id,
+              plexData.index,
+              true,
+            );
+            this.logger.log(
+              `[Sonarr] Removed season ${plexData.index} from show '${sonarrMedia.title}'`,
+            );
+            break;
+          case EPlexDataType.EPISODES:
+            await sonarrApiClient.UnmonitorDeleteEpisodes(
+              sonarrMedia.id,
+              plexData.parentIndex,
+              [plexData.index],
+              true,
+            );
+            this.logger.log(
+              `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
+            );
+            break;
+          default:
+            await sonarrApiClient.deleteShow(
+              sonarrMedia.id,
+              true,
+              collection.listExclusions,
+            );
+            this.logger.log(`Removed show ${sonarrMedia.title}' from Sonarr`);
+            break;
+        }
+        break;
+      case ServarrAction.UNMONITOR:
+        switch (collection.type) {
+          case EPlexDataType.SEASONS:
+            sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+              sonarrMedia.id,
+              plexData.index,
+              false,
+            );
+            this.logger.log(
+              `[Sonarr] Unmonitored season ${plexData.index} from show '${sonarrMedia.title}'`,
+            );
+            break;
+          case EPlexDataType.EPISODES:
+            await sonarrApiClient.UnmonitorDeleteEpisodes(
+              sonarrMedia.id,
+              plexData.parentIndex,
+              [plexData.index],
+              false,
+            );
+            this.logger.log(
+              `[Sonarr] Unmonitored season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
+            );
+            break;
+          default:
+            sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+              sonarrMedia.id,
+              'all',
+              false,
+            );
+
+            if (sonarrMedia) {
+              // unmonitor show
+              sonarrMedia.monitored = false;
+              sonarrApiClient.updateSeries(sonarrMedia);
+              this.logger.log(
+                `[Sonarr] Unmonitored show '${sonarrMedia.title}'`,
+              );
+            }
+
+            break;
+        }
+        break;
+      case ServarrAction.UNMONITOR_DELETE_ALL:
+        switch (collection.type) {
+          case EPlexDataType.SHOWS:
+            sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+              sonarrMedia.id,
+              'all',
+              true,
+            );
+
+            if (sonarrMedia) {
+              // unmonitor show
+              sonarrMedia.monitored = false;
+              sonarrApiClient.updateSeries(sonarrMedia);
+              this.logger.log(
+                `[Sonarr] Unmonitored show '${sonarrMedia.title}' and removed all episodes`,
+              );
+            }
+
+            break;
+          default:
+            this.logger.warn(
+              `[Sonarr] UNMONITOR_DELETE_ALL is not supported for type: ${collection.type}`,
+            );
+            break;
+        }
+        break;
+      case ServarrAction.UNMONITOR_DELETE_EXISTING:
+        switch (collection.type) {
+          case EPlexDataType.SEASONS:
+            sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+              sonarrMedia.id,
+              plexData.index,
+              true,
+              true,
+            );
+            this.logger.log(
+              `[Sonarr] Removed exisiting episodes from season ${plexData.index} from show '${sonarrMedia.title}'`,
+            );
+            break;
+          case EPlexDataType.SHOWS:
+            sonarrMedia = await sonarrApiClient.unmonitorSeasons(
+              sonarrMedia.id,
+              'existing',
+              true,
+            );
+
+            if (sonarrMedia) {
+              // unmonitor show
+              sonarrMedia.monitored = false;
+              sonarrApiClient.updateSeries(sonarrMedia);
+              this.logger.log(
+                `[Sonarr] Unmonitored show '${sonarrMedia.title}' and Removed exisiting episodes`,
+              );
+            }
+
+            break;
+          default:
+            this.logger.warn(
+              `[Sonarr] UNMONITOR_DELETE_EXISTING is not supported for type: ${collection.type}`,
+            );
+            break;
+        }
+        break;
+    }
+  }
+}

--- a/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
+++ b/server/src/modules/api/plex-api/interfaces/library.interfaces.ts
@@ -80,6 +80,7 @@ export interface PlexLibrary {
 
 export interface PlexLibrariesResponse {
   MediaContainer: {
+    totalSize: number;
     Directory: PlexLibrary[];
   };
 }

--- a/server/src/modules/api/plex-api/plex-api.service.ts
+++ b/server/src/modules/api/plex-api/plex-api.service.ts
@@ -199,6 +199,30 @@ export class PlexApiService {
     }
   }
 
+  public async getLibraryContentCount(
+    id: string | number,
+    datatype?: EPlexDataType,
+  ): Promise<number | undefined> {
+    try {
+      const type = datatype ? '?type=' + datatype : '';
+      const response = await this.plexClient.query<PlexLibrariesResponse>({
+        uri: `/library/sections/${id}/all${type}`,
+        extraHeaders: {
+          'X-Plex-Container-Start': '0',
+          'X-Plex-Container-Size': '0',
+        },
+      });
+
+      return response.MediaContainer.totalSize;
+    } catch (err) {
+      this.logger.warn(
+        'Plex api communication failure.. Is the application running?',
+      );
+      this.logger.debug(err);
+      return undefined;
+    }
+  }
+
   public async getLibraryContents(
     id: string,
     { offset = 0, size = 50 }: { offset?: number; size?: number } = {},

--- a/server/src/modules/api/servarr-api/interfaces/radarr.interface.ts
+++ b/server/src/modules/api/servarr-api/interfaces/radarr.interface.ts
@@ -22,16 +22,15 @@ export interface RadarrMovie {
   titleSlug: string;
   folderName: string;
   path: string;
-  profileId: number;
   qualityProfileId: number;
   added: string;
   downloaded: boolean;
   hasFile: boolean;
   movieFile: RadarrMovieFile;
   sizeOnDisk: number;
-  physicalRelease: string;
-  digitalRelease: string;
-  inCinemas: string;
+  physicalRelease?: string;
+  digitalRelease?: string;
+  inCinemas?: string;
   tags: number[];
   ratings: RadarrRatings;
 }

--- a/server/src/modules/api/servarr-api/interfaces/sonarr.interface.ts
+++ b/server/src/modules/api/servarr-api/interfaces/sonarr.interface.ts
@@ -83,12 +83,22 @@ export interface SonarrEpisodeFile {
   qualityCutoffNotMet: boolean;
 }
 
+export const SonarrSeriesStatusTypes = [
+  'deleted',
+  'ended',
+  'continuing',
+  'upcoming',
+] as const;
+export type SonarrSeriesStatusType = (typeof SonarrSeriesStatusTypes)[number];
+
+export const SonarrSeriesTypes = ['standard', 'daily', 'anime'] as const;
+export type SonarrSeriesType = (typeof SonarrSeriesTypes)[number];
+
 export interface SonarrSeries {
   title: string;
   sortTitle: string;
   originalLanguage: SonarrLanguage;
-  seasonCount: number;
-  status: string;
+  status: SonarrSeriesStatusType | null;
   overview: string;
   network: string;
   airTime: string;
@@ -100,8 +110,6 @@ export interface SonarrSeries {
   seasons: SonarrSeason[];
   year: number;
   path: string;
-  profileId: number;
-  languageProfileId: number;
   seasonFolder: boolean;
   monitored: boolean;
   useSceneNumbering: boolean;
@@ -111,7 +119,7 @@ export interface SonarrSeries {
   tvMazeId: number;
   firstAired: string;
   lastInfoSync?: string;
-  seriesType: 'standard' | 'daily' | 'anime';
+  seriesType: SonarrSeriesType;
   cleanTitle: string;
   imdbId: string;
   titleSlug: string;
@@ -138,25 +146,6 @@ export interface SonarrSeries {
 export interface SonarrLanguage {
   id: number;
   name: string | null;
-}
-
-export interface AddSeriesOptions {
-  tvdbid: number;
-  title: string;
-  profileId: number;
-  languageProfileId?: number;
-  seasons: number[];
-  seasonFolder: boolean;
-  rootFolderPath: string;
-  tags?: number[];
-  seriesType: SonarrSeries['seriesType'];
-  monitored?: boolean;
-  searchNow?: boolean;
-}
-
-export interface LanguageProfile {
-  id: number;
-  name: string;
 }
 
 export interface SonarrStatistics {

--- a/server/src/modules/collections/collection-handler.spec.ts
+++ b/server/src/modules/collections/collection-handler.spec.ts
@@ -1,0 +1,89 @@
+import { Mocked, TestBed } from '@suites/unit';
+import {
+  createCollection,
+  createCollectionMedia,
+  createPlexLibraries,
+} from '../../utils/testing/data';
+import { RadarrActionHandler } from '../actions/radarr-action-handler';
+import { SonarrActionHandler } from '../actions/sonarr-action-handler';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { CollectionHandler } from './collection-handler';
+import { CollectionsService } from './collections.service';
+import { ServarrAction } from './interfaces/collection.interface';
+
+describe('CollectionHandler', () => {
+  let collectionHandler: CollectionHandler;
+  let plexApi: Mocked<PlexApiService>;
+  let collectionsService: Mocked<CollectionsService>;
+  let radarrActionHandler: Mocked<RadarrActionHandler>;
+  let sonarrActionHandler: Mocked<SonarrActionHandler>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } =
+      await TestBed.solitary(CollectionHandler).compile();
+
+    collectionHandler = unit;
+    plexApi = unitRef.get(PlexApiService);
+    collectionsService = unitRef.get(CollectionsService);
+    radarrActionHandler = unitRef.get(RadarrActionHandler);
+    sonarrActionHandler = unitRef.get(SonarrActionHandler);
+  });
+
+  it('should delete from disk', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'show');
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+      }),
+    );
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.removeFromCollection).toHaveBeenCalledTimes(1);
+    expect(plexApi.deleteMediaFromDisk).toHaveBeenCalled();
+  });
+
+  it('should call Radarr action handler', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      radarrSettingsId: 1,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'movie');
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+        type: 'movie',
+      }),
+    );
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.removeFromCollection).toHaveBeenCalledTimes(1);
+    expect(radarrActionHandler.handleAction).toHaveBeenCalled();
+  });
+
+  it('should call Sonarr action handler', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      sonarrSettingsId: 1,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'show');
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.removeFromCollection).toHaveBeenCalledTimes(1);
+    expect(sonarrActionHandler.handleAction).toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/collections/collection-handler.spec.ts
+++ b/server/src/modules/collections/collection-handler.spec.ts
@@ -3,7 +3,7 @@ import {
   createCollection,
   createCollectionMedia,
   createPlexLibraries,
-} from '../../utils/testing/data';
+} from '../../../test/utils/data';
 import { RadarrActionHandler } from '../actions/radarr-action-handler';
 import { SonarrActionHandler } from '../actions/sonarr-action-handler';
 import { PlexApiService } from '../api/plex-api/plex-api.service';

--- a/server/src/modules/collections/collection-handler.ts
+++ b/server/src/modules/collections/collection-handler.ts
@@ -1,0 +1,110 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RadarrActionHandler } from '../actions/radarr-action-handler';
+import { SonarrActionHandler } from '../actions/sonarr-action-handler';
+import { OverseerrApiService } from '../api/overseerr-api/overseerr-api.service';
+import { EPlexDataType } from '../api/plex-api/enums/plex-data-type-enum';
+import { PlexMetadata } from '../api/plex-api/interfaces/media.interface';
+import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { SettingsService } from '../settings/settings.service';
+import { CollectionsService } from './collections.service';
+import { Collection } from './entities/collection.entities';
+import { CollectionMedia } from './entities/collection_media.entities';
+import { ServarrAction } from './interfaces/collection.interface';
+
+@Injectable()
+export class CollectionHandler {
+  private readonly logger = new Logger(CollectionHandler.name);
+
+  constructor(
+    private readonly plexApi: PlexApiService,
+    private readonly collectionService: CollectionsService,
+    private readonly overseerrApi: OverseerrApiService,
+    private readonly settings: SettingsService,
+    private readonly radarrActionHandler: RadarrActionHandler,
+    private readonly sonarrActionHandler: SonarrActionHandler,
+  ) {}
+
+  public async handleMedia(collection: Collection, media: CollectionMedia) {
+    if (collection.arrAction === ServarrAction.DO_NOTHING) {
+      return;
+    }
+
+    const plexData: PlexMetadata = undefined;
+
+    const plexLibrary = (await this.plexApi.getLibraries()).find(
+      (e) => +e.key === +collection.libraryId,
+    );
+
+    // TODO Media should only be removed from the collection if the handle action is performed successfully
+    await this.collectionService.removeFromCollection(collection.id, [
+      {
+        plexId: media.plexId,
+      },
+    ]);
+
+    // update handled media amount
+    collection.handledMediaAmount++;
+
+    // save a log record for the handled media item
+    this.collectionService.CollectionLogRecordForChild(
+      media.plexId,
+      collection.id,
+      'handle',
+    );
+
+    this.collectionService.saveCollection(collection);
+
+    if (plexLibrary.type === 'movie' && collection.radarrSettingsId) {
+      await this.radarrActionHandler.handleAction(collection, media);
+    } else if (plexLibrary.type == 'show' && collection.sonarrSettingsId) {
+      await this.sonarrActionHandler.handleAction(collection, media);
+    } else if (!collection.radarrSettingsId && !collection.sonarrSettingsId) {
+      if (collection.arrAction !== ServarrAction.UNMONITOR) {
+        this.logger.log(
+          `Couldn't utilize *arr to find and remove the media with id ${media.plexId}. Attempting to remove from the filesystem via Plex. No unmonitor action was taken.`,
+        );
+        await this.plexApi.deleteMediaFromDisk(media.plexId.toString());
+      } else {
+        this.logger.log(
+          `*arr unmonitor action isn't possible, since *arr is not available. Didn't unmonitor media with id ${media.plexId}.}`,
+        );
+      }
+    }
+
+    // Only remove requests & file if needed
+    if (collection.arrAction !== ServarrAction.UNMONITOR) {
+      // overseerr, if forced. Otherwise rely on media sync
+      if (this.settings.overseerrConfigured() && collection.forceOverseerr) {
+        switch (collection.type) {
+          case EPlexDataType.SEASONS:
+            await this.overseerrApi.removeSeasonRequest(
+              media.tmdbId,
+              plexData.index,
+            );
+            this.logger.log(
+              `[Overseerr] Removed request of season ${plexData.index} from show with tmdbid '${media.tmdbId}'`,
+            );
+            break;
+          case EPlexDataType.EPISODES:
+            await this.overseerrApi.removeSeasonRequest(
+              media.tmdbId,
+              plexData.parentIndex,
+            );
+            this.logger.log(
+              `[Overseerr] Removed request of season ${plexData.parentIndex} from show with tmdbid '${media.tmdbId}'. Because episode ${plexData.index} was removed.'`,
+            );
+            break;
+          default:
+            await this.overseerrApi.removeMediaByTmdbId(
+              media.tmdbId,
+              plexLibrary.type === 'show' ? 'tv' : 'movie',
+            );
+            this.logger.log(
+              `[Overseerr] Removed requests of media with tmdbid '${media.tmdbId}'`,
+            );
+            break;
+        }
+      }
+    }
+  }
+}

--- a/server/src/modules/collections/collection-worker.server.spec.ts
+++ b/server/src/modules/collections/collection-worker.server.spec.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import {
   createCollection,
   createCollectionMedia,
-} from '../../utils/testing/data';
+} from '../../../test/utils/data';
 import { JellyseerrApiService } from '../api/jellyseerr-api/jellyseerr-api.service';
 import { OverseerrApiService } from '../api/overseerr-api/overseerr-api.service';
 import { SettingsService } from '../settings/settings.service';

--- a/server/src/modules/collections/collection-worker.server.spec.ts
+++ b/server/src/modules/collections/collection-worker.server.spec.ts
@@ -1,0 +1,102 @@
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Mocked, TestBed } from '@suites/unit';
+import { Repository } from 'typeorm';
+import {
+  createCollection,
+  createCollectionMedia,
+} from '../../utils/testing/data';
+import { JellyseerrApiService } from '../api/jellyseerr-api/jellyseerr-api.service';
+import { OverseerrApiService } from '../api/overseerr-api/overseerr-api.service';
+import { SettingsService } from '../settings/settings.service';
+import { TasksService } from '../tasks/tasks.service';
+import { CollectionHandler } from './collection-handler';
+import { CollectionWorkerService } from './collection-worker.service';
+import { Collection } from './entities/collection.entities';
+import { CollectionMedia } from './entities/collection_media.entities';
+import { ServarrAction } from './interfaces/collection.interface';
+
+jest.mock('../../utils/delay');
+
+describe('CollectionWorkerService', () => {
+  let collectionWorkerService: CollectionWorkerService;
+  let taskService: Mocked<TasksService>;
+  let settings: Mocked<SettingsService>;
+  let collectionRepository: Mocked<Repository<Collection>>;
+  let collectionMediaRepository: Mocked<Repository<CollectionMedia>>;
+  let overseerrApi: Mocked<OverseerrApiService>;
+  let jellyseerrApi: Mocked<JellyseerrApiService>;
+  let collectionHandler: Mocked<CollectionHandler>;
+
+  beforeEach(async () => {
+    const { unit, unitRef } = await TestBed.solitary(
+      CollectionWorkerService,
+    ).compile();
+
+    collectionWorkerService = unit;
+    taskService = unitRef.get(TasksService);
+    settings = unitRef.get(SettingsService);
+    collectionRepository = unitRef.get(
+      getRepositoryToken(Collection) as string,
+    );
+    collectionMediaRepository = unitRef.get(
+      getRepositoryToken(CollectionMedia) as string,
+    );
+    overseerrApi = unitRef.get(OverseerrApiService);
+    jellyseerrApi = unitRef.get(JellyseerrApiService);
+    collectionHandler = unitRef.get(CollectionHandler);
+  });
+
+  it('should abort if another instance is running', async () => {
+    taskService.isRunning.mockResolvedValue(true);
+
+    await collectionWorkerService.execute();
+
+    expect(taskService.waitUntilTaskIsFinished).not.toHaveBeenCalled();
+  });
+
+  it('should abort if testing connection fails', async () => {
+    settings.testConnections.mockResolvedValue(false);
+
+    await collectionWorkerService.execute();
+
+    expect(taskService.waitUntilTaskIsFinished).toHaveBeenCalled();
+    expect(collectionRepository.find).not.toHaveBeenCalled();
+  });
+
+  it('should not handle media for Do Nothing collections', async () => {
+    settings.testConnections.mockResolvedValue(true);
+
+    const collection = createCollection({
+      arrAction: ServarrAction.DO_NOTHING,
+    });
+
+    collectionRepository.find.mockResolvedValue([collection]);
+    collectionMediaRepository.find.mockResolvedValue([]);
+
+    await collectionWorkerService.execute();
+
+    expect(taskService.waitUntilTaskIsFinished).toHaveBeenCalled();
+    expect(collectionRepository.find).toHaveBeenCalled();
+    expect(collectionHandler.handleMedia).not.toHaveBeenCalled();
+  });
+
+  it('should handle media for collection and trigger availability syncs', async () => {
+    settings.testConnections.mockResolvedValue(true);
+    settings.overseerrConfigured.mockReturnValue(true);
+    settings.jellyseerrConfigured.mockReturnValue(true);
+
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'show');
+
+    collectionRepository.find.mockResolvedValue([collection]);
+    collectionMediaRepository.find.mockResolvedValue([collectionMedia]);
+
+    await collectionWorkerService.execute();
+
+    expect(collectionHandler.handleMedia).toHaveBeenCalled();
+    expect(overseerrApi.api.post).toHaveBeenCalled();
+    expect(jellyseerrApi.api.post).toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/collections/collection-worker.service.ts
+++ b/server/src/modules/collections/collection-worker.service.ts
@@ -1,6 +1,6 @@
 import {
   CollectionHandlerFinishedEventDto,
-  CollectionHandlerProgressEventDto,
+  CollectionHandlerProgressedEventDto,
   CollectionHandlerStartedEventDto,
   MaintainerrEvent,
 } from '@maintainerr/contracts';
@@ -126,44 +126,44 @@ export class CollectionWorkerService extends TaskBase {
       });
     }
 
-    const progressEvent = new CollectionHandlerProgressEventDto();
-    const emitProgressEvent = () => {
-      progressEvent.time = new Date();
+    const progressedEvent = new CollectionHandlerProgressedEventDto();
+    const emitProgressedEvent = () => {
+      progressedEvent.time = new Date();
       this.eventEmitter.emit(
-        MaintainerrEvent.CollectionHandler_Progress,
-        progressEvent,
+        MaintainerrEvent.CollectionHandler_Progressed,
+        progressedEvent,
       );
     };
-    progressEvent.totalCollections = collectionsToHandle.length;
-    progressEvent.totalMediaToHandle = collectionHandleMediaGroup.reduce(
+    progressedEvent.totalCollections = collectionsToHandle.length;
+    progressedEvent.totalMediaToHandle = collectionHandleMediaGroup.reduce(
       (acc, curr) => acc + curr.mediaToHandle.length,
       0,
     );
-    emitProgressEvent();
+    emitProgressedEvent();
 
     for (const collectionGroup of collectionHandleMediaGroup) {
       const collection = collectionGroup.collection;
       const collectionMedia = collectionGroup.mediaToHandle;
 
-      progressEvent.processingCollection = {
+      progressedEvent.processingCollection = {
         name: collection.title,
         processedMedias: 0,
         totalMedias: collectionMedia.length,
       };
-      emitProgressEvent();
+      emitProgressedEvent();
 
       this.infoLogger(`Handling collection '${collection.title}'`);
 
       for (const media of collectionMedia) {
         await this.collectionHandler.handleMedia(collection, media);
         handledCollectionMedia++;
-        progressEvent.processingCollection.processedMedias++;
-        progressEvent.processedMedias++;
-        emitProgressEvent();
+        progressedEvent.processingCollection.processedMedias++;
+        progressedEvent.processedMedias++;
+        emitProgressedEvent();
       }
 
-      progressEvent.processedCollections++;
-      emitProgressEvent();
+      progressedEvent.processedCollections++;
+      emitProgressedEvent();
 
       this.infoLogger(`Handling collection '${collection.title}' finished`);
     }

--- a/server/src/modules/collections/collection-worker.service.ts
+++ b/server/src/modules/collections/collection-worker.service.ts
@@ -7,19 +7,14 @@ import {
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { LessThanOrEqual, Repository } from 'typeorm';
+import { delay } from '../../utils/delay';
 import { JellyseerrApiService } from '../api/jellyseerr-api/jellyseerr-api.service';
 import { OverseerrApiService } from '../api/overseerr-api/overseerr-api.service';
-import { EPlexDataType } from '../api/plex-api/enums/plex-data-type-enum';
-import { PlexMetadata } from '../api/plex-api/interfaces/media.interface';
-import { PlexApiService } from '../api/plex-api/plex-api.service';
-import { ServarrService } from '../api/servarr-api/servarr.service';
-import { TmdbIdService } from '../api/tmdb-api/tmdb-id.service';
-import { TmdbApiService } from '../api/tmdb-api/tmdb.service';
 import { SettingsService } from '../settings/settings.service';
 import { TaskBase } from '../tasks/task.base';
 import { TasksService } from '../tasks/tasks.service';
-import { CollectionsService } from './collections.service';
+import { CollectionHandler } from './collection-handler';
 import { Collection } from './entities/collection.entities';
 import { CollectionMedia } from './entities/collection_media.entities';
 import { ServarrAction } from './interfaces/collection.interface';
@@ -36,17 +31,12 @@ export class CollectionWorkerService extends TaskBase {
     private readonly collectionRepo: Repository<Collection>,
     @InjectRepository(CollectionMedia)
     private readonly collectionMediaRepo: Repository<CollectionMedia>,
-    private readonly collectionService: CollectionsService,
-    private readonly plexApi: PlexApiService,
     private readonly overseerrApi: OverseerrApiService,
     private readonly jellyseerrApi: JellyseerrApiService,
-    private readonly servarrApi: ServarrService,
-    private readonly tmdbApi: TmdbApiService,
     protected readonly taskService: TasksService,
     private readonly settings: SettingsService,
-    private readonly tmdbIdService: TmdbIdService,
-    private readonly tmdbIdHelper: TmdbIdService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly collectionHandler: CollectionHandler,
   ) {
     super(taskService);
   }
@@ -74,7 +64,7 @@ export class CollectionWorkerService extends TaskBase {
     await super.execute();
 
     // wait 5 seconds to make sure we're not executing together with the rule handler
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    await delay(5000);
 
     // if we are, then wait..
     await this.taskService.waitUntilTaskIsFinished('Rule Handler', this.name);
@@ -119,17 +109,15 @@ export class CollectionWorkerService extends TaskBase {
     }[] = [];
 
     for (const collection of collectionsToHandle) {
-      const collectionMedia = await this.collectionMediaRepo.find({
+      const dangerDate = new Date(
+        new Date().getTime() - +collection.deleteAfterDays * 86400000,
+      );
+
+      const mediaToHandle = await this.collectionMediaRepo.find({
         where: {
           collectionId: collection.id,
+          addDate: LessThanOrEqual(dangerDate),
         },
-      });
-
-      const mediaToHandle = collectionMedia.filter((media) => {
-        const dangerDate = new Date(
-          new Date().getTime() - +collection.deleteAfterDays * 86400000,
-        );
-        return new Date(media.addDate) <= dangerDate;
       });
 
       collectionHandleMediaGroup.push({
@@ -167,7 +155,7 @@ export class CollectionWorkerService extends TaskBase {
       this.infoLogger(`Handling collection '${collection.title}'`);
 
       for (const media of collectionMedia) {
-        await this.handleMedia(collection, media);
+        await this.collectionHandler.handleMedia(collection, media);
         handledCollectionMedia++;
         progressEvent.processingCollection.processedMedias++;
         progressEvent.processedMedias++;
@@ -181,41 +169,50 @@ export class CollectionWorkerService extends TaskBase {
     }
 
     if (handledCollectionMedia > 0) {
+      const promises = [];
       if (this.settings.overseerrConfigured()) {
-        setTimeout(() => {
-          this.overseerrApi.api
-            .post('/settings/jobs/availability-sync/run')
-            .then(() => {
+        promises.push(
+          delay(7000, async () => {
+            try {
+              await this.overseerrApi.api.post(
+                '/settings/jobs/availability-sync/run',
+              );
+
               this.infoLogger(
                 `All collections handled. Triggered Overseerr's availability-sync because media was altered`,
               );
-            })
-            .catch((err) => {
+            } catch (err) {
               this.logger.error(
                 `Failed to trigger Overseerr's availability-sync: ${err}`,
               );
               this.logger.debug(err);
-            });
-        }, 7000);
+            }
+          }),
+        );
       }
 
       if (this.settings.jellyseerrConfigured()) {
-        setTimeout(() => {
-          this.jellyseerrApi.api
-            .post('/settings/jobs/availability-sync/run')
-            .then(() => {
+        promises.push(
+          delay(7000, async () => {
+            try {
+              await this.jellyseerrApi.api.post(
+                '/settings/jobs/availability-sync/run',
+              );
+
               this.infoLogger(
                 `All collections handled. Triggered Jellyseerr's availability-sync because media was altered`,
               );
-            })
-            .catch((err) => {
+            } catch (err) {
               this.logger.error(
                 `Failed to trigger Jellyseerr's availability-sync: ${err}`,
               );
               this.logger.debug(err);
-            });
-        }, 7000);
+            }
+          }),
+        );
       }
+
+      await Promise.all(promises);
     } else {
       this.infoLogger(`All collections handled. No data was altered`);
     }
@@ -226,413 +223,6 @@ export class CollectionWorkerService extends TaskBase {
       MaintainerrEvent.CollectionHandler_Finished,
       new CollectionHandlerFinishedEventDto('Finished collection handling'),
     );
-  }
-
-  private async handleMedia(collection: Collection, media: CollectionMedia) {
-    if (collection.arrAction === ServarrAction.DO_NOTHING) {
-      // Sanity check, ideally we shouldn't ever call handleMedia on a collection with servarr
-      // action DO_NOTHING, but if we do, ensure we do nothing.
-      return;
-    }
-    let plexData: PlexMetadata = undefined;
-
-    const plexLibrary = (await this.plexApi.getLibraries()).find(
-      (e) => +e.key === +collection.libraryId,
-    );
-
-    await this.collectionService.removeFromCollection(collection.id, [
-      {
-        plexId: media.plexId,
-      },
-    ]);
-
-    // update handled media amount
-    collection.handledMediaAmount++;
-
-    // save a log record for the handled media item
-    this.collectionService.CollectionLogRecordForChild(
-      media.plexId,
-      collection.id,
-      'handle',
-    );
-
-    this.collectionService.saveCollection(collection);
-
-    const radarrApiClient = collection.radarrSettingsId
-      ? await this.servarrApi.getRadarrApiClient(collection.radarrSettingsId)
-      : undefined;
-
-    const sonarrApiClient = collection.sonarrSettingsId
-      ? await this.servarrApi.getSonarrApiClient(collection.sonarrSettingsId)
-      : undefined;
-
-    if (plexLibrary.type === 'movie' && radarrApiClient) {
-      // find tmdbid
-      const tmdbid = media.tmdbId
-        ? media.tmdbId
-        : (
-            await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
-              media.plexId.toString(),
-            )
-          )?.id;
-
-      if (tmdbid) {
-        const radarrMedia = await radarrApiClient.getMovieByTmdbId(tmdbid);
-        if (radarrMedia && radarrMedia.id) {
-          switch (collection.arrAction) {
-            case ServarrAction.DELETE:
-              await radarrApiClient.deleteMovie(
-                radarrMedia.id,
-                true,
-                collection.listExclusions,
-              );
-              this.infoLogger('Removed movie from filesystem & Radarr');
-              break;
-            case ServarrAction.UNMONITOR:
-              await radarrApiClient.unmonitorMovie(radarrMedia.id, false);
-              this.infoLogger('Unmonitored movie in Radarr');
-              break;
-            case ServarrAction.UNMONITOR_DELETE_ALL:
-              await radarrApiClient.unmonitorMovie(radarrMedia.id, true);
-              this.infoLogger('Unmonitored movie in Radarr & removed files');
-              break;
-            case ServarrAction.UNMONITOR_DELETE_EXISTING:
-              await radarrApiClient.deleteMovie(
-                radarrMedia.id,
-                true,
-                collection.listExclusions,
-              );
-              this.infoLogger('Removed movie from filesystem & Radarr');
-              break;
-          }
-        } else {
-          if (collection.arrAction !== ServarrAction.UNMONITOR) {
-            this.infoLogger(
-              `Couldn't find movie with tmdb id ${tmdbid} in Radarr, so no Radarr action was taken for movie with Plex ID ${media.plexId}. Attempting to remove from the filesystem via Plex.`,
-            );
-            this.plexApi.deleteMediaFromDisk(media.plexId.toString());
-          } else {
-            this.infoLogger(
-              `Radarr unmonitor action was not possible, couldn't find movie with tmdb id ${tmdbid} in Radarr. No action was taken for movie with Plex ID ${media.plexId}`,
-            );
-          }
-        }
-      } else {
-        this.infoLogger(
-          `Couldn't find correct tmdb id. No action taken for movie with Plex ID: ${media.plexId}. Please check this movie manually`,
-        );
-      }
-    } else if (plexLibrary.type == 'show' && sonarrApiClient) {
-      // get the tvdb id
-      let tvdbId = undefined;
-      switch (collection.type) {
-        case EPlexDataType.SEASONS:
-          plexData = await this.plexApi.getMetadata(media.plexId.toString());
-          tvdbId = await this.tvdbidFinder({
-            ...media,
-            ...{ plexID: plexData.parentRatingKey },
-          });
-          media.tmdbId = media.tmdbId
-            ? media.tmdbId
-            : (
-                await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
-                  plexData.parentRatingKey,
-                )
-              )?.id;
-          break;
-        case EPlexDataType.EPISODES:
-          plexData = await this.plexApi.getMetadata(media.plexId.toString());
-          tvdbId = await this.tvdbidFinder({
-            ...media,
-            ...{ plexID: plexData.grandparentRatingKey },
-          });
-          media.tmdbId = media.tmdbId
-            ? media.tmdbId
-            : (
-                await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
-                  plexData.grandparentRatingKey.toString(),
-                )
-              )?.id;
-          break;
-        default:
-          tvdbId = await this.tvdbidFinder(media);
-          media.tmdbId = media.tmdbId
-            ? media.tmdbId
-            : (
-                await this.tmdbIdService.getTmdbIdFromPlexRatingKey(
-                  media.plexId.toString(),
-                )
-              )?.id;
-          break;
-      }
-
-      if (tvdbId) {
-        let sonarrMedia = await sonarrApiClient.getSeriesByTvdbId(tvdbId);
-        if (sonarrMedia?.id) {
-          switch (collection.arrAction) {
-            case ServarrAction.DELETE:
-              switch (collection.type) {
-                case EPlexDataType.SEASONS:
-                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                    sonarrMedia.id,
-                    plexData.index,
-                    true,
-                  );
-                  this.infoLogger(
-                    `[Sonarr] Removed season ${plexData.index} from show '${sonarrMedia.title}'`,
-                  );
-                  break;
-                case EPlexDataType.EPISODES:
-                  await sonarrApiClient.UnmonitorDeleteEpisodes(
-                    sonarrMedia.id,
-                    plexData.parentIndex,
-                    [plexData.index],
-                    true,
-                  );
-                  this.infoLogger(
-                    `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
-                  );
-                  break;
-                default:
-                  await sonarrApiClient.deleteShow(
-                    sonarrMedia.id,
-                    true,
-                    collection.listExclusions,
-                  );
-                  this.infoLogger(
-                    `Removed show ${sonarrMedia.title}' from Sonarr`,
-                  );
-                  break;
-              }
-              break;
-            case ServarrAction.UNMONITOR:
-              switch (collection.type) {
-                case EPlexDataType.SEASONS:
-                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                    sonarrMedia.id,
-                    plexData.index,
-                    false,
-                  );
-                  this.infoLogger(
-                    `[Sonarr] Unmonitored season ${plexData.index} from show '${sonarrMedia.title}'`,
-                  );
-                  break;
-                case EPlexDataType.EPISODES:
-                  await sonarrApiClient.UnmonitorDeleteEpisodes(
-                    sonarrMedia.id,
-                    plexData.parentIndex,
-                    [plexData.index],
-                    false,
-                  );
-                  this.infoLogger(
-                    `[Sonarr] Unmonitored season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
-                  );
-                  break;
-                default:
-                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                    sonarrMedia.id,
-                    'all',
-                    false,
-                  );
-
-                  if (sonarrMedia) {
-                    // unmonitor show
-                    sonarrMedia.monitored = false;
-                    sonarrApiClient.updateSeries(sonarrMedia);
-                    this.infoLogger(
-                      `[Sonarr] Unmonitored show '${sonarrMedia.title}'`,
-                    );
-                  }
-
-                  break;
-              }
-              break;
-            case ServarrAction.UNMONITOR_DELETE_ALL:
-              switch (collection.type) {
-                case EPlexDataType.SEASONS:
-                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                    sonarrMedia.id,
-                    plexData.index,
-                    true,
-                  );
-                  this.infoLogger(
-                    `[Sonarr] Removed season ${plexData.index} from show '${sonarrMedia.title}'`,
-                  );
-                  break;
-                case EPlexDataType.EPISODES:
-                  await sonarrApiClient.UnmonitorDeleteEpisodes(
-                    sonarrMedia.id,
-                    plexData.parentIndex,
-                    [plexData.index],
-                    true,
-                  );
-                  this.infoLogger(
-                    `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
-                  );
-                  break;
-                default:
-                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                    sonarrMedia.id,
-                    'all',
-                    true,
-                  );
-
-                  if (sonarrMedia) {
-                    // unmonitor show
-                    sonarrMedia.monitored = false;
-                    sonarrApiClient.updateSeries(sonarrMedia);
-                    this.infoLogger(
-                      `[Sonarr] Unmonitored show '${sonarrMedia.title}' and removed all episodes`,
-                    );
-                  }
-
-                  break;
-              }
-              break;
-            case ServarrAction.UNMONITOR_DELETE_EXISTING:
-              switch (collection.type) {
-                case EPlexDataType.SEASONS:
-                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                    sonarrMedia.id,
-                    plexData.index,
-                    true,
-                    true,
-                  );
-                  this.infoLogger(
-                    `[Sonarr] Removed exisiting episodes from season ${plexData.index} from show '${sonarrMedia.title}'`,
-                  );
-                  break;
-                case EPlexDataType.EPISODES:
-                  await sonarrApiClient.UnmonitorDeleteEpisodes(
-                    sonarrMedia.id,
-                    plexData.parentIndex,
-                    [plexData.index],
-                    true,
-                  );
-                  this.infoLogger(
-                    `[Sonarr] Removed season ${plexData.parentIndex} episode ${plexData.index} from show '${sonarrMedia.title}'`,
-                  );
-                  break;
-                default:
-                  sonarrMedia = await sonarrApiClient.unmonitorSeasons(
-                    sonarrMedia.id,
-                    'existing',
-                    true,
-                  );
-
-                  if (sonarrMedia) {
-                    // unmonitor show
-                    sonarrMedia.monitored = false;
-                    sonarrApiClient.updateSeries(sonarrMedia);
-                    this.infoLogger(
-                      `[Sonarr] Unmonitored show '${sonarrMedia.title}' and Removed exisiting episodes`,
-                    );
-                  }
-
-                  break;
-              }
-              break;
-          }
-        } else {
-          if (collection.arrAction !== ServarrAction.UNMONITOR) {
-            this.infoLogger(
-              `Couldn't find correct tvdb id. No Sonarr action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}. Attempting to remove from the filesystem via Plex.`,
-            );
-            this.plexApi.deleteMediaFromDisk(media.plexId.toString());
-          } else {
-            this.infoLogger(
-              `Couldn't find correct tvdb id. No unmonitor action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}`,
-            );
-          }
-        }
-      } else {
-        this.infoLogger(
-          `Couldn't find correct tvdb id. No action was taken for show: https://www.themoviedb.org/tv/${media.tmdbId}. Please check this show manually`,
-        );
-      }
-    } else if (!radarrApiClient && !sonarrApiClient) {
-      if (collection.arrAction !== ServarrAction.UNMONITOR) {
-        this.infoLogger(
-          `Couldn't utilize *arr to find and remove the media with id ${media.plexId}. Attempting to remove from the filesystem via Plex. No unmonitor action was taken.`,
-        );
-        await this.plexApi.deleteMediaFromDisk(media.plexId.toString());
-      } else {
-        this.infoLogger(
-          `*arr unmonitor action isn't possible, since *arr is not available. Didn't unmonitor media with id ${media.plexId}.}`,
-        );
-      }
-    }
-
-    // Only remove requests & file if needed
-    if (collection.arrAction !== ServarrAction.UNMONITOR) {
-      // overseerr, if forced. Otherwise rely on media sync
-      if (this.settings.overseerrConfigured() && collection.forceOverseerr) {
-        switch (collection.type) {
-          case EPlexDataType.SEASONS:
-            await this.overseerrApi.removeSeasonRequest(
-              media.tmdbId,
-              plexData.index,
-            );
-            this.infoLogger(
-              `[Overseerr] Removed request of season ${plexData.index} from show with tmdbid '${media.tmdbId}'`,
-            );
-            break;
-          case EPlexDataType.EPISODES:
-            await this.overseerrApi.removeSeasonRequest(
-              media.tmdbId,
-              plexData.parentIndex,
-            );
-            this.infoLogger(
-              `[Overseerr] Removed request of season ${plexData.parentIndex} from show with tmdbid '${media.tmdbId}'. Because episode ${plexData.index} was removed.'`,
-            );
-            break;
-          default:
-            await this.overseerrApi.removeMediaByTmdbId(
-              media.tmdbId,
-              plexLibrary.type === 'show' ? 'tv' : 'movie',
-            );
-            this.infoLogger(
-              `[Overseerr] Removed requests of media with tmdbid '${media.tmdbId}'`,
-            );
-            break;
-        }
-      }
-    }
-  }
-
-  private async tvdbidFinder(media: CollectionMedia) {
-    let tvdbid = undefined;
-    if (!media.tmdbId && media.plexId) {
-      media.tmdbId = (
-        await this.tmdbIdHelper.getTmdbIdFromPlexRatingKey(
-          media.plexId.toString(),
-        )
-      )?.id;
-    }
-
-    const tmdbShow = media.tmdbId
-      ? await this.tmdbApi.getTvShow({ tvId: media.tmdbId })
-      : undefined;
-
-    if (!tmdbShow?.external_ids?.tvdb_id) {
-      let plexData = await this.plexApi.getMetadata(media.plexId.toString());
-      // fetch correct record for seasons & episodes
-      plexData = plexData.grandparentRatingKey
-        ? await this.plexApi.getMetadata(
-            plexData.grandparentRatingKey.toString(),
-          )
-        : plexData.parentRatingKey
-          ? await this.plexApi.getMetadata(plexData.parentRatingKey.toString())
-          : plexData;
-
-      const tvdbidPlex = plexData?.Guid?.find((el) => el.id.includes('tvdb'));
-      if (tvdbidPlex) {
-        tvdbid = tvdbidPlex.id.split('tvdb://')[1];
-      }
-    } else {
-      tvdbid = tmdbShow.external_ids.tvdb_id;
-    }
-    return tvdbid;
   }
 
   private infoLogger(message: string) {

--- a/server/src/modules/collections/collections.controller.ts
+++ b/server/src/modules/collections/collections.controller.ts
@@ -3,19 +3,21 @@ import {
   Controller,
   Delete,
   Get,
+  HttpException,
+  HttpStatus,
   Param,
   ParseIntPipe,
   Post,
   Put,
   Query,
 } from '@nestjs/common';
+import { ECollectionLogType } from '../collections/entities/collection_log.entities';
 import { CollectionWorkerService } from './collection-worker.service';
 import { CollectionsService } from './collections.service';
 import {
   AddCollectionMedia,
   IAlterableMediaDto,
 } from './interfaces/collection-media.interface';
-import { ECollectionLogType } from '../collections/entities/collection_log.entities';
 
 @Controller('api/collections')
 export class CollectionsController {
@@ -63,7 +65,14 @@ export class CollectionsController {
   }
 
   @Post('/handle')
-  handleCollection() {
+  async handleCollection() {
+    if (await this.collectionWorkerService.isRunning()) {
+      throw new HttpException(
+        'The collection handler is already running',
+        HttpStatus.CONFLICT,
+      );
+    }
+
     this.collectionWorkerService.execute().catch((e) => console.error(e));
   }
 

--- a/server/src/modules/collections/collections.module.ts
+++ b/server/src/modules/collections/collections.module.ts
@@ -1,21 +1,23 @@
 import { Module } from '@nestjs/common';
-import { PlexApiModule } from '../api/plex-api/plex-api.module';
-import { CollectionsService } from './collections.service';
-import { CollectionsController } from './collections.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Collection } from './entities/collection.entities';
-import { CollectionMedia } from './entities/collection_media.entities';
-import { TmdbApiModule } from '../api/tmdb-api/tmdb.module';
-import { CollectionWorkerService } from './collection-worker.service';
+import { ActionsModule } from '../actions/actions.module';
+import { JellyseerrApiModule } from '../api/jellyseerr-api/jellyseerr-api.module';
 import { OverseerrApiModule } from '../api/overseerr-api/overseerr-api.module';
+import { PlexApiModule } from '../api/plex-api/plex-api.module';
 import { ServarrApiModule } from '../api/servarr-api/servarr-api.module';
-import { RuleGroup } from '../rules/entities/rule-group.entities';
-import { TasksModule } from '../tasks/tasks.module';
-import { Exclusion } from '../rules/entities/exclusion.entities';
+import { TautulliApiModule } from '../api/tautulli-api/tautulli-api.module';
+import { TmdbApiModule } from '../api/tmdb-api/tmdb.module';
 import { CollectionLog } from '../collections/entities/collection_log.entities';
 import { CollectionLogCleanerService } from '../collections/tasks/collection-log-cleaner.service';
-import { TautulliApiModule } from '../api/tautulli-api/tautulli-api.module';
-import { JellyseerrApiModule } from '../api/jellyseerr-api/jellyseerr-api.module';
+import { Exclusion } from '../rules/entities/exclusion.entities';
+import { RuleGroup } from '../rules/entities/rule-group.entities';
+import { TasksModule } from '../tasks/tasks.module';
+import { CollectionHandler } from './collection-handler';
+import { CollectionWorkerService } from './collection-worker.service';
+import { CollectionsController } from './collections.controller';
+import { CollectionsService } from './collections.service';
+import { Collection } from './entities/collection.entities';
+import { CollectionMedia } from './entities/collection_media.entities';
 
 @Module({
   imports: [
@@ -33,11 +35,13 @@ import { JellyseerrApiModule } from '../api/jellyseerr-api/jellyseerr-api.module
     TmdbApiModule,
     ServarrApiModule,
     TasksModule,
+    ActionsModule,
   ],
   providers: [
     CollectionsService,
     CollectionWorkerService,
     CollectionLogCleanerService,
+    CollectionHandler,
   ],
   controllers: [CollectionsController],
   exports: [CollectionsService],

--- a/server/src/modules/collections/entities/collection_media.entities.ts
+++ b/server/src/modules/collections/entities/collection_media.entities.ts
@@ -1,12 +1,12 @@
 import {
-  Entity,
   Column,
-  PrimaryGeneratedColumn,
-  ManyToOne,
+  Entity,
   Index,
+  ManyToOne,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
-import { Collection } from './collection.entities';
 import { PlexMetadata } from '../../api/plex-api/interfaces/media.interface';
+import { Collection } from './collection.entities';
 
 @Entity()
 @Index('idx_collection_media_collection_id', ['collectionId'])
@@ -36,6 +36,8 @@ export class CollectionMedia {
     onDelete: 'CASCADE',
   })
   collection: Collection;
+}
 
-  plexData: PlexMetadata; // this will be added programatically
+export class CollectionMediaWithPlexData extends CollectionMedia {
+  plexData: PlexMetadata;
 }

--- a/server/src/modules/events/events.controller.ts
+++ b/server/src/modules/events/events.controller.ts
@@ -1,10 +1,10 @@
 import {
   BaseEventDto,
   CollectionHandlerFinishedEventDto,
-  CollectionHandlerProgressEventDto,
+  CollectionHandlerProgressedEventDto,
   CollectionHandlerStartedEventDto,
   RuleHandlerFinishedEventDto,
-  RuleHandlerProgressEventDto,
+  RuleHandlerProgressedEventDto,
   RuleHandlerStartedEventDto,
 } from '@maintainerr/contracts';
 import {
@@ -102,10 +102,10 @@ export class EventsController {
   sendEventToClient(
     payload:
       | RuleHandlerStartedEventDto
-      | RuleHandlerProgressEventDto
+      | RuleHandlerProgressedEventDto
       | RuleHandlerFinishedEventDto
       | CollectionHandlerStartedEventDto
-      | CollectionHandlerProgressEventDto
+      | CollectionHandlerProgressedEventDto
       | CollectionHandlerFinishedEventDto,
   ) {
     const eventMessage: NestMessageEvent = {

--- a/server/src/modules/events/events.controller.ts
+++ b/server/src/modules/events/events.controller.ts
@@ -1,0 +1,103 @@
+import {
+  BaseEventDto,
+  CollectionHandlerFinishedEventDto,
+  CollectionHandlerProgressEventDto,
+  CollectionHandlerStartedEventDto,
+  RuleHandlerFinishedEventDto,
+  RuleHandlerProgressEventDto,
+  RuleHandlerStartedEventDto,
+} from '@maintainerr/contracts';
+import {
+  Controller,
+  Get,
+  MessageEvent as NestMessageEvent,
+  Res,
+} from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Response } from 'express';
+import { Subject } from 'rxjs';
+
+@Controller('/api/events')
+export class EventsController {
+  private mostRecentEvent: NestMessageEvent | null = null;
+
+  connectedClients = new Map<
+    string,
+    { close: () => void; subject: Subject<NestMessageEvent> }
+  >();
+
+  // Source: https://github.com/nestjs/nest/issues/12670
+  @Get('stream')
+  async stream(@Res() response: Response) {
+    const subject = new Subject<NestMessageEvent>();
+
+    const observer = {
+      next: (msg: NestMessageEvent) => {
+        if (msg.type) response.write(`event: ${msg.type}\n`);
+        if (msg.id) response.write(`id: ${msg.id}\n`);
+        if (msg.retry) response.write(`retry: ${msg.retry}\n`);
+
+        response.write(`data: ${JSON.stringify(msg.data)}\n\n`);
+      },
+    };
+
+    subject.subscribe(observer);
+
+    const clientKey = String(Math.random());
+    this.connectedClients.set(clientKey, {
+      close: () => {
+        response.end();
+      },
+      subject,
+    });
+
+    response.on('close', () => {
+      subject.complete();
+      this.connectedClients.delete(clientKey);
+      response.end();
+    });
+
+    response.set({
+      'Cache-Control':
+        'private, no-cache, no-store, must-revalidate, max-age=0, no-transform',
+      Connection: 'keep-alive',
+      'Content-Type': 'text/event-stream',
+    });
+
+    response.flushHeaders();
+
+    if (this.mostRecentEvent) {
+      const eventTime = (this.mostRecentEvent.data as BaseEventDto).time;
+      if (eventTime > new Date(Date.now() - 5000)) {
+        this.sendDataToClient(clientKey, this.mostRecentEvent);
+      }
+    }
+  }
+
+  @OnEvent('rule_handler.*')
+  @OnEvent('collection_handler.*')
+  sendEventToClient(
+    payload:
+      | RuleHandlerStartedEventDto
+      | RuleHandlerProgressEventDto
+      | RuleHandlerFinishedEventDto
+      | CollectionHandlerStartedEventDto
+      | CollectionHandlerProgressEventDto
+      | CollectionHandlerFinishedEventDto,
+  ) {
+    const eventMessage: NestMessageEvent = {
+      type: payload.type,
+      data: payload,
+    };
+
+    for (const [, client] of this.connectedClients) {
+      client.subject.next(eventMessage);
+    }
+
+    this.mostRecentEvent = eventMessage;
+  }
+
+  sendDataToClient(clientId: string, message: NestMessageEvent) {
+    this.connectedClients.get(clientId)?.subject.next(message);
+  }
+}

--- a/server/src/modules/events/events.module.ts
+++ b/server/src/modules/events/events.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { EventsController } from './events.controller';
+import { EventsService } from './events.service';
+
+@Module({
+  providers: [EventsService],
+  exports: [EventsService],
+  controllers: [EventsController],
+})
+export class EventsModule {}

--- a/server/src/modules/events/events.module.ts
+++ b/server/src/modules/events/events.module.ts
@@ -1,10 +1,9 @@
 import { Module } from '@nestjs/common';
 import { EventsController } from './events.controller';
-import { EventsService } from './events.service';
 
 @Module({
-  providers: [EventsService],
-  exports: [EventsService],
+  providers: [],
+  exports: [],
   controllers: [EventsController],
 })
 export class EventsModule {}

--- a/server/src/modules/events/events.service.ts
+++ b/server/src/modules/events/events.service.ts
@@ -1,0 +1,6 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class EventsService {
+  constructor() {}
+}

--- a/server/src/modules/events/events.service.ts
+++ b/server/src/modules/events/events.service.ts
@@ -1,6 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class EventsService {
-  constructor() {}
-}

--- a/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -77,6 +77,7 @@ export class RuleComparatorService {
     rulegroup: RulesDto,
     plexData: PlexLibraryItem[],
     withStats = false,
+    onRuleProgress?: (processingRule: number) => void,
   ): Promise<IComparatorReturnValue> {
     try {
       // prepare
@@ -95,7 +96,12 @@ export class RuleComparatorService {
       // prepare statistics if needed
       this.prepareStatistics();
 
+      let ruleNumber = 0;
+
       for (const rule of rulegroup.rules) {
+        ruleNumber++;
+        onRuleProgress?.(ruleNumber);
+
         const parsedRule = JSON.parse((rule as RuleDbDto).ruleJson) as RuleDto;
 
         // force operator of very first rule to null, otherwise this might cause corruption

--- a/server/src/modules/rules/rules.controller.ts
+++ b/server/src/modules/rules/rules.controller.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   Delete,
   Get,
+  HttpException,
+  HttpStatus,
   Param,
   Post,
   Put,
@@ -11,8 +13,8 @@ import {
 import { CommunityRule } from './dtos/communityRule.dto';
 import { ExclusionAction, ExclusionContextDto } from './dtos/exclusion.dto';
 import { RulesDto } from './dtos/rules.dto';
-import { RuleExecutorService } from './tasks/rule-executor.service';
 import { ReturnStatus, RulesService } from './rules.service';
+import { RuleExecutorService } from './tasks/rule-executor.service';
 
 @Controller('api/rules')
 export class RulesController {
@@ -85,7 +87,14 @@ export class RulesController {
     return this.rulesService.deleteRuleGroup(+id);
   }
   @Post('/execute')
-  executeRules() {
+  async executeRules() {
+    if (await this.ruleExecutorService.isRunning()) {
+      throw new HttpException(
+        'The rule executor is already running',
+        HttpStatus.CONFLICT,
+      );
+    }
+
     this.ruleExecutorService.execute().catch((e) => console.error(e));
   }
   @Post()

--- a/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -1,7 +1,7 @@
 import {
   MaintainerrEvent,
   RuleHandlerFinishedEventDto,
-  RuleHandlerProgressEventDto,
+  RuleHandlerProgressedEventDto,
   RuleHandlerStartedEventDto,
 } from '@maintainerr/contracts';
 import { Injectable, Logger } from '@nestjs/common';
@@ -101,28 +101,28 @@ export class RuleExecutorService extends TaskBase {
             ruleGroupTotals[rulegroup.id] = mediaItemCount;
           }
 
-          const progressEvent = new RuleHandlerProgressEventDto();
-          const emitProgressEvent = () => {
-            progressEvent.time = new Date();
+          const progressedEvent = new RuleHandlerProgressedEventDto();
+          const emitProgressedEvent = () => {
+            progressedEvent.time = new Date();
             this.eventEmitter.emit(
-              MaintainerrEvent.CollectionHandler_Progress,
-              progressEvent,
+              MaintainerrEvent.CollectionHandler_Progressed,
+              progressedEvent,
             );
           };
-          progressEvent.totalRuleGroups = ruleGroups.length;
-          progressEvent.totalEvaluations = totalEvaluations;
+          progressedEvent.totalRuleGroups = ruleGroups.length;
+          progressedEvent.totalEvaluations = totalEvaluations;
 
           for (let i = 0; i < ruleGroups.length; i++) {
             const rulegroup = ruleGroups[i];
 
-            progressEvent.processingRuleGroup = {
+            progressedEvent.processingRuleGroup = {
               name: rulegroup.name,
               number: i + 1,
               processedEvaluations: 0,
               totalEvaluations:
                 ruleGroupTotals[rulegroup.id] * rulegroup.rules.length,
             };
-            emitProgressEvent();
+            emitProgressedEvent();
 
             if (rulegroup.useRules) {
               this.logger.log(`Executing rules for '${rulegroup.name}'`);
@@ -150,11 +150,11 @@ export class RuleExecutorService extends TaskBase {
                   this.plexData.data,
                   false,
                   () => {
-                    progressEvent.processedEvaluations +=
+                    progressedEvent.processedEvaluations +=
                       this.plexData.data.length;
-                    progressEvent.processingRuleGroup.processedEvaluations +=
+                    progressedEvent.processingRuleGroup.processedEvaluations +=
                       this.plexData.data.length;
-                    emitProgressEvent();
+                    emitProgressedEvent();
                   },
                 );
 

--- a/server/src/modules/rules/tests/rule.comparator.service.doRuleAction.spec.ts
+++ b/server/src/modules/rules/tests/rule.comparator.service.doRuleAction.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@automock/jest';
+import { TestBed } from '@suites/unit';
 import { RulePossibility } from '../constants/rules.constants';
 import { ValueGetterService } from '../getter/getter.service';
 import { RuleComparatorService } from '../helpers/rule.comparator.service';
@@ -7,10 +7,9 @@ describe('RuleComparatorService', () => {
   let ruleComparatorService: RuleComparatorService;
 
   beforeEach(async () => {
-    const { unit } = TestBed.create(RuleComparatorService)
-
+    const { unit } = await TestBed.solitary(RuleComparatorService)
       .mock(ValueGetterService)
-      .using({ get: jest.fn() })
+      .final({ get: jest.fn() })
       .compile();
 
     ruleComparatorService = unit;

--- a/server/src/modules/rules/tests/rule.comparator.service.doRuleAction.spec.ts
+++ b/server/src/modules/rules/tests/rule.comparator.service.doRuleAction.spec.ts
@@ -269,11 +269,6 @@ describe('RuleComparatorService', () => {
       [false, ['a1', 'b2', 'c3'], 4, RulePossibility.COUNT_EQUALS],
       [false, ['a1', 'b2', 'c3'], 3, RulePossibility.COUNT_NOT_EQUALS],
       [true, ['a1', 'b2', 'c3'], 4, RulePossibility.COUNT_NOT_EQUALS],
-      // Number lists
-      [true, [1, 2, 3], 3, RulePossibility.COUNT_EQUALS],
-      [false, [1, 2, 3], 4, RulePossibility.COUNT_EQUALS],
-      [false, [1, 2, 3], 3, RulePossibility.COUNT_NOT_EQUALS],
-      [true, [1, 2, 3], 4, RulePossibility.COUNT_NOT_EQUALS],
 
       // > and <
       // Text lists
@@ -283,13 +278,6 @@ describe('RuleComparatorService', () => {
       [true, ['a1', 'b2', 'c3'], 4, RulePossibility.COUNT_SMALLER],
       [false, ['a1', 'b2', 'c3'], 3, RulePossibility.COUNT_SMALLER],
       [false, ['a1', 'b2', 'c3'], 2, RulePossibility.COUNT_SMALLER],
-      // Number lists
-      [true, [1, 2, 3], 2, RulePossibility.COUNT_BIGGER],
-      [false, [1, 2, 3], 3, RulePossibility.COUNT_BIGGER],
-      [false, [1, 2, 3], 4, RulePossibility.COUNT_BIGGER],
-      [true, [1, 2, 3], 4, RulePossibility.COUNT_SMALLER],
-      [false, [1, 2, 3], 3, RulePossibility.COUNT_SMALLER],
-      [false, [1, 2, 3], 2, RulePossibility.COUNT_SMALLER],
     ] as const;
     const actionName = {
       [RulePossibility.COUNT_EQUALS]: 'COUNT_EQUALS',

--- a/server/src/modules/tasks/task.base.ts
+++ b/server/src/modules/tasks/task.base.ts
@@ -50,7 +50,7 @@ export class TaskBase implements OnApplicationBootstrap {
     return this.taskService.updateJob(this.name, cron, this.execute.bind(this));
   }
 
-  protected async isRunning() {
+  public async isRunning() {
     return await this.taskService.isRunning(this.name);
   }
 }

--- a/server/src/modules/tasks/tasks.controller.ts
+++ b/server/src/modules/tasks/tasks.controller.ts
@@ -1,0 +1,17 @@
+import { TaskStatusDto } from '@maintainerr/contracts';
+import { Controller, Get, Param } from '@nestjs/common';
+import { TasksService } from './tasks.service';
+
+@Controller('/api/tasks')
+export class TasksController {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Get(':id/status')
+  async getTaskStatus(@Param('id') id: string): Promise<TaskStatusDto> {
+    return {
+      time: new Date(),
+      running: await this.tasksService.isRunning(id),
+      runningSince: await this.tasksService.getRunningSince(id),
+    };
+  }
+}

--- a/server/src/modules/tasks/tasks.module.ts
+++ b/server/src/modules/tasks/tasks.module.ts
@@ -1,13 +1,15 @@
 import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
-import { StatusService } from './status.service';
-import { TasksService } from './tasks.service';
-import { TaskRunning } from '../tasks/entities/task_running.entities';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { TaskRunning } from '../tasks/entities/task_running.entities';
+import { StatusService } from './status.service';
+import { TasksController } from './tasks.controller';
+import { TasksService } from './tasks.service';
 
 @Module({
   imports: [ScheduleModule.forRoot(), TypeOrmModule.forFeature([TaskRunning])],
   providers: [TasksService, StatusService],
   exports: [TasksService],
+  controllers: [TasksController],
 })
 export class TasksModule {}

--- a/server/src/modules/tasks/tasks.service.ts
+++ b/server/src/modules/tasks/tasks.service.ts
@@ -1,12 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { CronExpression, SchedulerRegistry } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
 import { CronJob } from 'cron';
+import { Repository } from 'typeorm';
+import { TaskRunning } from '../tasks/entities/task_running.entities';
 import { Status } from './interfaces/status.interface';
 import { TaskScheduler } from './interfaces/task-scheduler.interface';
 import { StatusService } from './status.service';
-import { InjectRepository } from '@nestjs/typeorm';
-import { TaskRunning } from '../tasks/entities/task_running.entities';
-import { Repository } from 'typeorm';
 
 @Injectable()
 export class TasksService implements TaskScheduler {
@@ -136,6 +136,11 @@ export class TasksService implements TaskScheduler {
         },
       );
     }
+  }
+
+  public async getRunningSince(name: string) {
+    const resp = await this.taskRunningRepo.findOne({ where: { name } });
+    return resp.runningSince;
   }
 
   public async waitUntilTaskIsFinished(

--- a/server/src/utils/__mocks__/delay.ts
+++ b/server/src/utils/__mocks__/delay.ts
@@ -1,0 +1,7 @@
+export const delay = (ms: number, fn?: () => Promise<void> | void) => {
+  if (fn) {
+    return fn();
+  }
+
+  return Promise.resolve();
+};

--- a/server/src/utils/delay.ts
+++ b/server/src/utils/delay.ts
@@ -1,0 +1,10 @@
+export const delay = (ms: number, fn?: () => Promise<void> | void) => {
+  return new Promise<void>((resolve) => {
+    setTimeout(async () => {
+      if (fn) {
+        await fn();
+      }
+      resolve();
+    }, ms);
+  });
+};

--- a/server/src/utils/testing/data.ts
+++ b/server/src/utils/testing/data.ts
@@ -1,0 +1,245 @@
+import { faker } from '@faker-js/faker';
+import { EPlexDataType } from '../../modules/api/plex-api/enums/plex-data-type-enum';
+import { PlexLibrary } from '../../modules/api/plex-api/interfaces/library.interfaces';
+import { PlexMetadata } from '../../modules/api/plex-api/interfaces/media.interface';
+import {
+  RadarrMovie,
+  RadarrMovieFile,
+} from '../../modules/api/servarr-api/interfaces/radarr.interface';
+import {
+  SonarrSeries,
+  SonarrSeriesStatusTypes,
+  SonarrSeriesTypes,
+} from '../../modules/api/servarr-api/interfaces/sonarr.interface';
+import { Collection } from '../../modules/collections/entities/collection.entities';
+import {
+  CollectionMedia,
+  CollectionMediaWithPlexData,
+} from '../../modules/collections/entities/collection_media.entities';
+import { ServarrAction } from '../../modules/collections/interfaces/collection.interface';
+
+export const createCollection = (
+  properties: Partial<Collection> = {},
+): Collection => {
+  return {
+    id: faker.number.int(),
+    title: faker.string.sample(10),
+    description: '',
+    isActive: true,
+    arrAction: ServarrAction.DELETE,
+    type: EPlexDataType.MOVIES,
+    libraryId: faker.number.int(),
+    plexId: faker.number.int(),
+    addDate: faker.date.past(),
+    collectionLog: [],
+    collectionMedia: [],
+    deleteAfterDays: 30,
+    forceOverseerr: false,
+    handledMediaAmount: 0,
+    keepLogsForMonths: 6,
+    lastDurationInSeconds: 0,
+    manualCollection: false,
+    manualCollectionName: undefined,
+    radarrSettings: undefined,
+    radarrSettingsId: undefined,
+    sonarrSettings: undefined,
+    sonarrSettingsId: undefined,
+    listExclusions: false,
+    ruleGroup: undefined,
+    visibleOnHome: false,
+    visibleOnRecommended: false,
+    tautulliWatchedPercentOverride: undefined,
+    ...properties,
+  };
+};
+
+export const createCollectionMedia = (
+  collection?: Collection,
+  type?: PlexMetadata['type'],
+  properties: Partial<CollectionMedia> = {},
+): CollectionMedia => {
+  const collectionToUse = collection ?? createCollection();
+
+  return {
+    id: faker.number.int(),
+    collection: collectionToUse,
+    collectionId: collectionToUse.id,
+    addDate: faker.date.past(),
+    image_path: '',
+    isManual: false,
+    plexId: faker.number.int(),
+    tmdbId: faker.number.int(),
+    ...properties,
+  };
+};
+
+export const createCollectionMediaWithPlexData = (
+  collection?: Collection,
+  type?: PlexMetadata['type'],
+  properties: Partial<CollectionMediaWithPlexData> = {},
+): CollectionMediaWithPlexData => {
+  return {
+    ...createCollectionMedia(collection, type, properties),
+    plexData: {
+      index: faker.number.int(),
+      addedAt: faker.date.past(),
+      title: faker.string.sample(10),
+      type:
+        type ??
+        faker.helpers.arrayElement(['movie', 'show', 'season', 'episode']),
+      ...properties.plexData,
+    },
+    ...properties,
+  };
+};
+
+export const createPlexLibraries = (
+  properties: Partial<PlexLibrary> = {},
+): PlexLibrary[] => {
+  return [
+    createPlexLibrary(properties),
+    createPlexLibrary(),
+    createPlexLibrary(),
+  ];
+};
+
+export const createPlexLibrary = (
+  properties: Partial<PlexLibrary> = {},
+): PlexLibrary => ({
+  agent: faker.string.sample(10),
+  type: faker.helpers.arrayElement(['movie', 'show']),
+  key: faker.string.sample(10),
+  title: faker.string.sample(10),
+  ...properties,
+});
+
+export const createRadarrMovie = (
+  properties: Partial<RadarrMovie> = {},
+): RadarrMovie => ({
+  title: faker.string.sample(10),
+  originalLanguage: {
+    id: 1,
+    name: 'English',
+  },
+  downloaded: faker.datatype.boolean(),
+  id: faker.number.int(),
+  hasFile: faker.datatype.boolean(),
+  monitored: faker.datatype.boolean(),
+  added: faker.date.past().toISOString(),
+  inCinemas: faker.date.past().toISOString(),
+  physicalRelease: faker.date.past().toISOString(),
+  digitalRelease: faker.date.past().toISOString(),
+  folderName: faker.system.directoryPath(),
+  isAvailable: faker.datatype.boolean(),
+  imdbId: faker.string.sample(10),
+  path: faker.system.directoryPath(),
+  tmdbId: faker.number.int(),
+  qualityProfileId: faker.number.int(),
+  movieFile: {
+    id: faker.number.int(),
+    dateAdded: faker.date.past().toISOString(),
+  } as RadarrMovieFile,
+  ratings: {
+    imdb: {
+      votes: faker.number.int(),
+      value: faker.number.float({ min: 0, max: 10 }),
+      type: 'user',
+    },
+    tmdb: {
+      votes: faker.number.int(),
+      value: faker.number.float({ min: 0, max: 10 }),
+      type: 'user',
+    },
+    metacritic: {
+      votes: faker.number.int(),
+      value: faker.number.float({ min: 0, max: 10 }),
+      type: 'user',
+    },
+    rottenTomatoes: {
+      votes: faker.number.int(),
+      value: faker.number.float({ min: 0, max: 10 }),
+      type: 'user',
+    },
+    trakt: {
+      votes: faker.number.int(),
+      value: faker.number.float({ min: 0, max: 10 }),
+      type: 'user',
+    },
+  },
+  sizeOnDisk: faker.number.int(),
+  tags: [],
+  titleSlug: faker.string.sample(10),
+  ...properties,
+});
+
+export const createSonarrSeries = (
+  properties: Partial<SonarrSeries> = {},
+): SonarrSeries => {
+  const title = faker.string.sample(10);
+
+  return {
+    title,
+    originalLanguage: {
+      id: 1,
+      name: 'English',
+    },
+    id: faker.number.int(),
+    monitored: faker.datatype.boolean(),
+    added: faker.date.past().toISOString(),
+    imdbId: faker.string.sample(10),
+    path: faker.system.directoryPath(),
+    tvdbId: faker.number.int(),
+    qualityProfileId: faker.number.int(),
+    ratings: {
+      votes: faker.number.int(),
+      value: faker.number.float({ min: 0, max: 10 }),
+    },
+    tags: [],
+    titleSlug: faker.string.sample(10),
+    sortTitle: title,
+    status: faker.helpers.arrayElement(SonarrSeriesStatusTypes),
+    overview: faker.string.sample(10),
+    network: faker.string.sample(10),
+    airTime: `${faker.number.int({ min: 0, max: 23 })}:${faker.number.int({
+      min: 0,
+      max: 59,
+    })}`,
+    images: [
+      {
+        coverType: 'poster',
+        url: faker.system.filePath(),
+      },
+      {
+        coverType: 'banner',
+        url: faker.system.filePath(),
+      },
+    ],
+    remotePoster: faker.internet.url(),
+    seasons: [
+      {
+        seasonNumber: 0,
+        monitored: faker.datatype.boolean(),
+      },
+      {
+        seasonNumber: 1,
+        monitored: faker.datatype.boolean(),
+      },
+      {
+        seasonNumber: 2,
+        monitored: faker.datatype.boolean(),
+      },
+    ],
+    year: faker.number.int(),
+    seasonFolder: faker.datatype.boolean(),
+    useSceneNumbering: faker.datatype.boolean(),
+    runtime: faker.number.int({ min: 0, max: 120 }),
+    tvRageId: faker.number.int(),
+    tvMazeId: faker.number.int(),
+    firstAired: faker.date.past().toISOString(),
+    seriesType: faker.helpers.arrayElement(SonarrSeriesTypes),
+    cleanTitle: title.replace(/\s+/g, '-').toLowerCase(),
+    certification: faker.string.sample(10),
+    genres: [faker.string.sample(10), faker.string.sample(10)],
+    ...properties,
+  };
+};

--- a/server/test/jest.setup.ts
+++ b/server/test/jest.setup.ts
@@ -1,0 +1,17 @@
+import { LoggerService } from '@nestjs/common';
+
+jest.mock('@nestjs/common', () => {
+  return {
+    ...jest.requireActual('@nestjs/common'),
+    Logger: function () {
+      return {
+        debug: jest.fn(),
+        log: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        fatal: jest.fn(),
+        verbose: jest.fn(),
+      } satisfies LoggerService;
+    },
+  };
+});

--- a/server/test/utils/data.ts
+++ b/server/test/utils/data.ts
@@ -1,22 +1,22 @@
 import { faker } from '@faker-js/faker';
-import { EPlexDataType } from '../../modules/api/plex-api/enums/plex-data-type-enum';
-import { PlexLibrary } from '../../modules/api/plex-api/interfaces/library.interfaces';
-import { PlexMetadata } from '../../modules/api/plex-api/interfaces/media.interface';
+import { EPlexDataType } from '../../src/modules/api/plex-api/enums/plex-data-type-enum';
+import { PlexLibrary } from '../../src/modules/api/plex-api/interfaces/library.interfaces';
+import { PlexMetadata } from '../../src/modules/api/plex-api/interfaces/media.interface';
 import {
   RadarrMovie,
   RadarrMovieFile,
-} from '../../modules/api/servarr-api/interfaces/radarr.interface';
+} from '../../src/modules/api/servarr-api/interfaces/radarr.interface';
 import {
   SonarrSeries,
   SonarrSeriesStatusTypes,
   SonarrSeriesTypes,
-} from '../../modules/api/servarr-api/interfaces/sonarr.interface';
-import { Collection } from '../../modules/collections/entities/collection.entities';
+} from '../../src/modules/api/servarr-api/interfaces/sonarr.interface';
+import { Collection } from '../../src/modules/collections/entities/collection.entities';
 import {
   CollectionMedia,
   CollectionMediaWithPlexData,
-} from '../../modules/collections/entities/collection_media.entities';
-import { ServarrAction } from '../../modules/collections/interfaces/collection.interface';
+} from '../../src/modules/collections/entities/collection_media.entities';
+import { ServarrAction } from '../../src/modules/collections/interfaces/collection.interface';
 
 export const createCollection = (
   properties: Partial<Collection> = {},

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/__mocks__/*"]
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "allowJs": true,
     "module": "CommonJS",
     "moduleDetection": "force",
     "declaration": true,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "module": "CommonJS",
     "moduleDetection": "force",
     "declaration": true,

--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -1,7 +1,8 @@
 import { FlatCompat } from '@eslint/eslintrc'
+import pluginQuery from '@tanstack/eslint-plugin-query'
+import eslintConfigPrettier from 'eslint-config-prettier'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import eslintConfigPrettier from 'eslint-config-prettier'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -22,6 +23,7 @@ const configs = [
       '@typescript-eslint/ban-ts-comment': 'off',
     },
   },
+  ...pluginQuery.configs['flat/recommended'],
   eslintConfigPrettier,
 ]
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@hookform/resolvers": "^4.1.3",
     "@maintainerr/contracts": "workspace:^",
     "@monaco-editor/react": "^4.7.0",
+    "@tanstack/react-query": "^5.67.3",
     "axios": "^1.8.2",
     "bowser": "^2.11.0",
     "clsx": "^2.1.1",
@@ -32,6 +33,7 @@
     "react-select": "^5.10.1",
     "react-toast-notifications": "^2.5.1",
     "react-transition-group": "^4.4.5",
+    "reconnecting-eventsource": "^1.6.4",
     "yaml": "^2.7.0",
     "zod": "^3.24.1"
   },
@@ -41,6 +43,7 @@
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
+    "@tanstack/eslint-plugin-query": "^5.67.2",
     "@types/lodash": "^4.17.15",
     "@types/node": "^22",
     "@types/react": "^18",

--- a/ui/src/components/Collection/CollectionOverview/index.tsx
+++ b/ui/src/components/Collection/CollectionOverview/index.tsx
@@ -1,5 +1,5 @@
-import { debounce } from 'lodash'
 import { ICollection } from '..'
+import { useTaskStatusContext } from '../../../contexts/taskstatus-context'
 import ExecuteButton from '../../Common/ExecuteButton'
 import LibrarySwitcher from '../../Common/LibrarySwitcher'
 import CollectionItem from '../CollectionItem'
@@ -12,6 +12,8 @@ interface ICollectionOverview {
 }
 
 const CollectionOverview = (props: ICollectionOverview) => {
+  const { collectionHandlerRunning } = useTaskStatusContext()
+
   return (
     <div>
       <LibrarySwitcher onSwitch={props.onSwitchLibrary} />
@@ -19,11 +21,9 @@ const CollectionOverview = (props: ICollectionOverview) => {
       <div className="m-auto mb-3 flex">
         <div className="m-auto sm:m-0">
           <ExecuteButton
-            onClick={debounce(props.doActions, 5000, {
-              leading: true,
-              trailing: false,
-            })}
+            onClick={props.doActions}
             text="Handle Collections"
+            executing={collectionHandlerRunning}
           />
         </div>
       </div>

--- a/ui/src/components/Common/ExecuteButton/index.tsx
+++ b/ui/src/components/Common/ExecuteButton/index.tsx
@@ -1,32 +1,20 @@
 import { PlayIcon } from '@heroicons/react/solid'
-import { useEffect, useState } from 'react'
 import { SmallLoadingSpinner } from '../LoadingSpinner'
 
 interface IExecuteButton {
   text: string
   onClick: () => void
+  executing?: boolean
 }
 
 const ExecuteButton = (props: IExecuteButton) => {
-  const [clicked, setClicked] = useState(false)
-
-  useEffect(() => {
-    setTimeout(() => {
-      setClicked(false)
-    }, 10000)
-  }, [clicked])
-  const onClick = () => {
-    setClicked(true)
-    props.onClick()
-  }
-
   return (
     <button
       className="edit-button m-auto flex h-9 rounded text-zinc-200 shadow-md"
-      disabled={clicked}
-      onClick={onClick}
+      onClick={props.onClick}
+      disabled={props.executing}
     >
-      {clicked ? (
+      {props.executing ? (
         <SmallLoadingSpinner className="m-auto ml-2 h-5" />
       ) : (
         <PlayIcon className="m-auto ml-4 h-5" />

--- a/ui/src/components/Layout/NavBar/index.tsx
+++ b/ui/src/components/Layout/NavBar/index.tsx
@@ -8,9 +8,10 @@ import {
 import Link from 'next/link'
 import { ReactNode, useContext, useEffect, useRef } from 'react'
 import SearchContext from '../../../contexts/search-context'
+import CachedImage from '../../Common/CachedImage'
+import Messages from '../../Messages/Messages'
 import Transition from '../../Transition'
 import VersionStatus from '../../VersionStatus'
-import CachedImage from '../../Common/CachedImage'
 
 interface NavBarLink {
   key: string
@@ -172,7 +173,8 @@ const NavBar: React.FC<NavBarProps> = ({ open, setClosed }) => {
                       })}
                     </nav>
                   </div>
-                  <span className="mb-4">
+                  <span className="mb-4 flex flex-col gap-y-4">
+                    <Messages />
                     <VersionStatus />
                   </span>
                 </div>
@@ -232,7 +234,10 @@ const NavBar: React.FC<NavBarProps> = ({ open, setClosed }) => {
                   )
                 })}
               </nav>
-              <VersionStatus />
+              <div className="flex flex-col gap-y-4">
+                <Messages />
+                <VersionStatus />
+              </div>
             </div>
           </div>
         </div>

--- a/ui/src/components/Messages/Messages.tsx
+++ b/ui/src/components/Messages/Messages.tsx
@@ -1,0 +1,224 @@
+import {
+  BaseEventDto,
+  CollectionHandlerFinishedEventDto,
+  CollectionHandlerProgressEventDto,
+  CollectionHandlerStartedEventDto,
+  MaintainerrEvent,
+  RuleHandlerFinishedEventDto,
+  RuleHandlerProgressEventDto,
+  RuleHandlerStartedEventDto,
+} from '@maintainerr/contracts'
+import { useRef, useState } from 'react'
+import { useEvent } from '../../contexts/events-context'
+import { SmallLoadingSpinner } from '../Common/LoadingSpinner'
+import Transition from '../Transition'
+
+const isStartedOrFinishedEvent = (
+  event: BaseEventDto,
+): event is
+  | CollectionHandlerStartedEventDto
+  | CollectionHandlerFinishedEventDto
+  | RuleHandlerStartedEventDto
+  | RuleHandlerFinishedEventDto => {
+  return (
+    event.type == MaintainerrEvent.CollectionHandler_Started ||
+    event.type == MaintainerrEvent.RuleHandler_Started ||
+    event.type == MaintainerrEvent.CollectionHandler_Finished ||
+    event.type == MaintainerrEvent.RuleHandler_Finished
+  )
+}
+
+const isRuleHandlerProgressEvent = (
+  event: BaseEventDto,
+): event is RuleHandlerProgressEventDto => {
+  return event.type == MaintainerrEvent.RuleHandler_Progress
+}
+
+const isCollectionHandlerProgressEvent = (
+  event: BaseEventDto,
+): event is CollectionHandlerProgressEventDto => {
+  return event.type == MaintainerrEvent.CollectionHandler_Progress
+}
+
+const Messages = () => {
+  return (
+    <div className="flex flex-col gap-y-4">
+      <RuleHandlerMessages />
+      <CollectionHandlerMessages />
+    </div>
+  )
+}
+
+const RuleHandlerMessages = () => {
+  const finishedTimer = useRef<NodeJS.Timeout>()
+  const [show, setShow] = useState<boolean>(false)
+
+  const [event, setEvent] = useState<
+    | RuleHandlerStartedEventDto
+    | RuleHandlerProgressEventDto
+    | RuleHandlerFinishedEventDto
+  >()
+
+  useEvent<RuleHandlerStartedEventDto>(
+    MaintainerrEvent.RuleHandler_Started,
+    (event) => {
+      setEvent(event)
+      setShow(true)
+      clearTimeout(finishedTimer.current)
+    },
+  )
+
+  useEvent<RuleHandlerProgressEventDto>(
+    MaintainerrEvent.RuleHandler_Progress,
+    (event) => {
+      setEvent(event)
+      setShow(true)
+      clearTimeout(finishedTimer.current)
+    },
+  )
+
+  useEvent<RuleHandlerFinishedEventDto>(
+    MaintainerrEvent.RuleHandler_Finished,
+    (event) => {
+      setEvent(event)
+      setShow(true)
+      finishedTimer.current = setTimeout(() => setShow(false), 5000)
+    },
+  )
+
+  return (
+    <Transition
+      show={show}
+      enter="transition opacity-0 duration-1000"
+      enterFrom="opacity-0"
+      enterTo="opacity-100"
+      leave="transition opacity-100 duration-1000"
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0"
+    >
+      <div
+        className={
+          'mx-2 flex flex-col rounded-lg bg-zinc-900 py-2 pl-2 pr-4 text-xs font-bold text-zinc-300 ring-1 ring-zinc-700'
+        }
+      >
+        <div className="flex items-center gap-2">
+          <div>
+            <SmallLoadingSpinner className="m-auto h-4 px-0.5" />
+          </div>
+          {event && isStartedOrFinishedEvent(event) && <>{event.message}</>}
+          {event &&
+            isRuleHandlerProgressEvent(event) &&
+            event.processingRuleGroup && (
+              <div>Processing: {event.processingRuleGroup.name}</div>
+            )}
+        </div>
+        {event && isRuleHandlerProgressEvent(event) && (
+          <div className="ml-8 mt-2 bg-zinc-800">
+            {event.totalRuleGroups > 1 && (
+              <div
+                className={`h-1.5 bg-amber-500 transition-width ease-in-out ${event.processingRuleGroup?.processedEvaluations === 0 ? 'duration-0' : 'duration-150'}`}
+                style={{
+                  width: `${(event.processingRuleGroup ? event.processingRuleGroup?.processedEvaluations / event.processingRuleGroup?.totalEvaluations : 0) * 100}%`,
+                }}
+              />
+            )}
+            <div
+              className="h-1.5 bg-amber-700 transition-width duration-150 ease-in-out"
+              style={{
+                width: `${(event.processedEvaluations / event.totalEvaluations) * 100}%`,
+              }}
+            />
+          </div>
+        )}
+      </div>
+    </Transition>
+  )
+}
+
+const CollectionHandlerMessages = () => {
+  const finishedTimer = useRef<NodeJS.Timeout>()
+  const [show, setShow] = useState<boolean>(false)
+
+  const [event, setEvent] = useState<
+    | CollectionHandlerStartedEventDto
+    | CollectionHandlerProgressEventDto
+    | CollectionHandlerFinishedEventDto
+  >()
+
+  useEvent<CollectionHandlerStartedEventDto>(
+    MaintainerrEvent.CollectionHandler_Started,
+    (event) => {
+      setEvent(event)
+      setShow(true)
+      clearTimeout(finishedTimer.current)
+    },
+  )
+
+  useEvent<CollectionHandlerProgressEventDto>(
+    MaintainerrEvent.CollectionHandler_Progress,
+    (event) => {
+      setEvent(event)
+      setShow(true)
+      clearTimeout(finishedTimer.current)
+    },
+  )
+
+  useEvent<CollectionHandlerFinishedEventDto>(
+    MaintainerrEvent.CollectionHandler_Finished,
+    (event) => {
+      setEvent(event)
+      setShow(true)
+      finishedTimer.current = setTimeout(() => setShow(false), 5000)
+    },
+  )
+
+  return (
+    <Transition
+      show={show}
+      enter="transition opacity-0 duration-1000"
+      enterFrom="opacity-0"
+      enterTo="opacity-100"
+      leave="transition opacity-100 duration-1000"
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0"
+    >
+      <div
+        className={
+          'mx-2 flex flex-col rounded-lg bg-zinc-900 py-2 pl-2 pr-4 text-xs font-bold text-zinc-300 ring-1 ring-zinc-700 hover:bg-zinc-800'
+        }
+      >
+        <div className="flex items-center gap-2">
+          <div>
+            <SmallLoadingSpinner className="m-auto h-4 px-0.5" />
+          </div>
+          {event && isStartedOrFinishedEvent(event) && <>{event.message}</>}
+          {event &&
+            isCollectionHandlerProgressEvent(event) &&
+            event.processingCollection && (
+              <div>Processing: {event.processingCollection.name}</div>
+            )}
+        </div>
+        {event && isCollectionHandlerProgressEvent(event) && (
+          <div className="ml-8 mt-2 bg-zinc-800">
+            {event.totalCollections > 1 && (
+              <div
+                className={`h-1.5 bg-amber-500 transition-width ease-in-out ${event.processingCollection?.processedMedias === 0 ? 'duration-0' : 'duration-150'}`}
+                style={{
+                  width: `${(event.processingCollection ? event.processingCollection?.processedMedias / event.processingCollection?.totalMedias : 0) * 100}%`,
+                }}
+              />
+            )}
+            <div
+              className="h-1.5 bg-amber-700 transition-width duration-150 ease-in-out"
+              style={{
+                width: `${(event.processedMedias / event.totalMediaToHandle) * 100}%`,
+              }}
+            />
+          </div>
+        )}
+      </div>
+    </Transition>
+  )
+}
+
+export default Messages

--- a/ui/src/components/Messages/Messages.tsx
+++ b/ui/src/components/Messages/Messages.tsx
@@ -1,11 +1,11 @@
 import {
   BaseEventDto,
   CollectionHandlerFinishedEventDto,
-  CollectionHandlerProgressEventDto,
+  CollectionHandlerProgressedEventDto,
   CollectionHandlerStartedEventDto,
   MaintainerrEvent,
   RuleHandlerFinishedEventDto,
-  RuleHandlerProgressEventDto,
+  RuleHandlerProgressedEventDto,
   RuleHandlerStartedEventDto,
 } from '@maintainerr/contracts'
 import { useRef, useState } from 'react'
@@ -28,16 +28,16 @@ const isStartedOrFinishedEvent = (
   )
 }
 
-const isRuleHandlerProgressEvent = (
+const isRuleHandlerProgressedEvent = (
   event: BaseEventDto,
-): event is RuleHandlerProgressEventDto => {
-  return event.type == MaintainerrEvent.RuleHandler_Progress
+): event is RuleHandlerProgressedEventDto => {
+  return event.type == MaintainerrEvent.RuleHandler_Progressed
 }
 
-const isCollectionHandlerProgressEvent = (
+const isCollectionHandlerProgressedEvent = (
   event: BaseEventDto,
-): event is CollectionHandlerProgressEventDto => {
-  return event.type == MaintainerrEvent.CollectionHandler_Progress
+): event is CollectionHandlerProgressedEventDto => {
+  return event.type == MaintainerrEvent.CollectionHandler_Progressed
 }
 
 const Messages = () => {
@@ -55,7 +55,7 @@ const RuleHandlerMessages = () => {
 
   const [event, setEvent] = useState<
     | RuleHandlerStartedEventDto
-    | RuleHandlerProgressEventDto
+    | RuleHandlerProgressedEventDto
     | RuleHandlerFinishedEventDto
   >()
 
@@ -68,8 +68,8 @@ const RuleHandlerMessages = () => {
     },
   )
 
-  useEvent<RuleHandlerProgressEventDto>(
-    MaintainerrEvent.RuleHandler_Progress,
+  useEvent<RuleHandlerProgressedEventDto>(
+    MaintainerrEvent.RuleHandler_Progressed,
     (event) => {
       setEvent(event)
       setShow(true)
@@ -107,12 +107,12 @@ const RuleHandlerMessages = () => {
           </div>
           {event && isStartedOrFinishedEvent(event) && <>{event.message}</>}
           {event &&
-            isRuleHandlerProgressEvent(event) &&
+            isRuleHandlerProgressedEvent(event) &&
             event.processingRuleGroup && (
               <div>Processing: {event.processingRuleGroup.name}</div>
             )}
         </div>
-        {event && isRuleHandlerProgressEvent(event) && (
+        {event && isRuleHandlerProgressedEvent(event) && (
           <div className="ml-8 mt-2 bg-zinc-800">
             {event.totalRuleGroups > 1 && (
               <div
@@ -141,7 +141,7 @@ const CollectionHandlerMessages = () => {
 
   const [event, setEvent] = useState<
     | CollectionHandlerStartedEventDto
-    | CollectionHandlerProgressEventDto
+    | CollectionHandlerProgressedEventDto
     | CollectionHandlerFinishedEventDto
   >()
 
@@ -154,8 +154,8 @@ const CollectionHandlerMessages = () => {
     },
   )
 
-  useEvent<CollectionHandlerProgressEventDto>(
-    MaintainerrEvent.CollectionHandler_Progress,
+  useEvent<CollectionHandlerProgressedEventDto>(
+    MaintainerrEvent.CollectionHandler_Progressed,
     (event) => {
       setEvent(event)
       setShow(true)
@@ -193,12 +193,12 @@ const CollectionHandlerMessages = () => {
           </div>
           {event && isStartedOrFinishedEvent(event) && <>{event.message}</>}
           {event &&
-            isCollectionHandlerProgressEvent(event) &&
+            isCollectionHandlerProgressedEvent(event) &&
             event.processingCollection && (
               <div>Processing: {event.processingCollection.name}</div>
             )}
         </div>
-        {event && isCollectionHandlerProgressEvent(event) && (
+        {event && isCollectionHandlerProgressedEvent(event) && (
           <div className="ml-8 mt-2 bg-zinc-800">
             {event.totalCollections > 1 && (
               <div

--- a/ui/src/components/Settings/Logs/index.tsx
+++ b/ui/src/components/Settings/Logs/index.tsx
@@ -8,6 +8,7 @@ import {
 } from '@maintainerr/contracts'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
+import ReconnectingEventSource from 'reconnecting-eventsource'
 import GetApiHandler, {
   API_BASE_PATH,
   PostApiHandler,
@@ -130,7 +131,7 @@ const Logs = () => {
   const logsRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    const es = new EventSource('/api/logs/stream')
+    const es = new ReconnectingEventSource('/api/logs/stream')
     es.addEventListener('log', (event) => {
       const message: LogEvent = JSON.parse(event.data)
       setLogLines((prev) => [...prev, message])

--- a/ui/src/contexts/events-context.tsx
+++ b/ui/src/contexts/events-context.tsx
@@ -1,0 +1,55 @@
+import { MaintainerrEvent } from '@maintainerr/contracts'
+import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import ReconnectingEventSource from 'reconnecting-eventsource'
+
+const EventsContext = createContext<EventSource | undefined>(undefined)
+
+export const EventsProvider = (props: any) => {
+  const [eventSource, setEventSource] = useState<EventSource>()
+
+  useEffect(() => {
+    const es = new ReconnectingEventSource('/api/events/stream')
+
+    es.onerror = (e) => {
+      console.error('EventSource failed:', e)
+    }
+
+    setEventSource(es)
+
+    return () => {
+      es.close()
+    }
+  }, [])
+
+  return <EventsContext.Provider value={eventSource} {...props} />
+}
+
+export const useEvent = <T,>(
+  type: MaintainerrEvent,
+  listener: (event: T) => any,
+) => {
+  const context = useContext(EventsContext)
+  const listenerAdded = useRef(listener)
+
+  useEffect(() => {
+    listenerAdded.current = listener
+  })
+
+  useEffect(() => {
+    if (!context) return
+
+    const options: AddEventListenerOptions = {
+      passive: true,
+    }
+
+    const parserListener = (ev: MessageEvent) => {
+      listenerAdded.current(JSON.parse(ev.data))
+    }
+
+    context.addEventListener(type, parserListener, options)
+
+    return () => {
+      context.removeEventListener(type, parserListener, options)
+    }
+  }, [context])
+}

--- a/ui/src/contexts/taskstatus-context.tsx
+++ b/ui/src/contexts/taskstatus-context.tsx
@@ -1,0 +1,146 @@
+import {
+  CollectionHandlerFinishedEventDto,
+  CollectionHandlerStartedEventDto,
+  MaintainerrEvent,
+  RuleHandlerFinishedEventDto,
+  RuleHandlerStartedEventDto,
+  TaskStatusDto,
+} from '@maintainerr/contracts'
+import { useQuery } from '@tanstack/react-query'
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import GetApiHandler from '../utils/ApiHandler'
+import { useEvent } from './events-context'
+
+export interface TaskStatusState {
+  ruleHandlerRunning?: TaskStatusDto
+  collectionHandlerRunning?: TaskStatusDto
+}
+
+export const TaskStatusContext = createContext<TaskStatusState | undefined>(
+  undefined,
+)
+
+export const TaskStatusProvider = (props: any) => {
+  const [ruleHandlerRunning, setRuleHandlerRunning] = useState<TaskStatusDto>()
+  const [collectionHandlerRunning, setCollectionHandlerRunning] =
+    useState<TaskStatusDto>()
+
+  // Rule handler
+  const ruleHandlerStatusQuery = useQuery({
+    queryKey: ['taskstatus_rulehandler'],
+    queryFn: async () => {
+      return await GetApiHandler<TaskStatusDto>('/tasks/Rule Handler/status')
+    },
+  })
+
+  const updateRuleExecutorRunning = (value: boolean, date: Date) => {
+    setRuleHandlerRunning((prev) => {
+      if (prev?.time && prev?.time > date) {
+        return prev
+      } else {
+        return {
+          time: date,
+          running: value,
+        }
+      }
+    })
+  }
+
+  useEvent<RuleHandlerStartedEventDto>(
+    MaintainerrEvent.RuleHandler_Started,
+    (event) => {
+      updateRuleExecutorRunning(true, event.time)
+    },
+  )
+
+  useEvent<RuleHandlerFinishedEventDto>(
+    MaintainerrEvent.RuleHandler_Finished,
+    (event) => {
+      updateRuleExecutorRunning(false, event.time)
+    },
+  )
+
+  useEffect(() => {
+    if (ruleHandlerStatusQuery.data) {
+      updateRuleExecutorRunning(
+        ruleHandlerStatusQuery.data.running,
+        ruleHandlerStatusQuery.data.time,
+      )
+    }
+  }, [ruleHandlerStatusQuery.data])
+
+  // Collection handler
+  const collectionHandlerStatusQuery = useQuery({
+    queryKey: ['taskstatus_collectionhandler'],
+    queryFn: async () => {
+      return await GetApiHandler<TaskStatusDto>(
+        '/tasks/Collection Handler/status',
+      )
+    },
+  })
+
+  const updateCollectionExecutorRunning = (value: boolean, date: Date) => {
+    setCollectionHandlerRunning((prev) => {
+      if (prev?.time && prev?.time > date) {
+        return prev
+      } else {
+        return {
+          time: date,
+          running: value,
+        }
+      }
+    })
+  }
+
+  useEvent<CollectionHandlerStartedEventDto>(
+    MaintainerrEvent.CollectionHandler_Started,
+    (event) => {
+      updateCollectionExecutorRunning(true, event.time)
+    },
+  )
+
+  useEvent<CollectionHandlerFinishedEventDto>(
+    MaintainerrEvent.CollectionHandler_Finished,
+    (event) => {
+      updateCollectionExecutorRunning(false, event.time)
+    },
+  )
+
+  useEffect(() => {
+    if (collectionHandlerStatusQuery.data) {
+      updateCollectionExecutorRunning(
+        collectionHandlerStatusQuery.data.running,
+        collectionHandlerStatusQuery.data.time,
+      )
+    }
+  }, [collectionHandlerStatusQuery.data])
+
+  const contextValue = useMemo(() => {
+    return {
+      ruleHandlerRunning,
+      collectionHandlerRunning,
+    } satisfies TaskStatusState
+  }, [ruleHandlerRunning, collectionHandlerRunning])
+
+  return <TaskStatusContext.Provider value={contextValue} {...props} />
+}
+
+export type TaskStatusContext = {
+  ruleHandlerRunning?: boolean
+  collectionHandlerRunning?: boolean
+}
+
+export const useTaskStatusContext = (): TaskStatusContext => {
+  const context = useContext(TaskStatusContext)
+
+  if (!context) {
+    throw new Error(
+      'useTaskStatusContext must be used within a TaskStatusProvider',
+    )
+  }
+
+  return {
+    ruleHandlerRunning: context.ruleHandlerRunning?.running,
+    collectionHandlerRunning: context.collectionHandlerRunning?.running,
+  }
+}

--- a/ui/src/middleware.ts
+++ b/ui/src/middleware.ts
@@ -1,12 +1,13 @@
-import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
 
 const apiPort = process.env.API_PORT || 3001
 
 export function middleware(request: NextRequest) {
   if (
     request.nextUrl.pathname.startsWith('/api/') &&
-    !request.nextUrl.pathname.startsWith('/api/logs/stream')
+    !request.nextUrl.pathname.startsWith('/api/logs/stream') &&
+    !request.nextUrl.pathname.startsWith('/api/events/stream')
   ) {
     const url = request.nextUrl.clone()
     const destination = new URL(`http://localhost:${apiPort}`)

--- a/ui/src/pages/_app.tsx
+++ b/ui/src/pages/_app.tsx
@@ -1,24 +1,35 @@
-import '../../styles/globals.css'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { AppProps } from 'next/app'
-import Layout from '../components/Layout'
-import { LibrariesContextProvider } from '../contexts/libraries-context'
-import { SettingsContextProvider } from '../contexts/settings-context'
-import { SearchContextProvider } from '../contexts/search-context'
 import { ToastProvider } from 'react-toast-notifications'
+import '../../styles/globals.css'
+import Layout from '../components/Layout'
+import { EventsProvider } from '../contexts/events-context'
+import { LibrariesContextProvider } from '../contexts/libraries-context'
+import { SearchContextProvider } from '../contexts/search-context'
+import { SettingsContextProvider } from '../contexts/settings-context'
+import { TaskStatusProvider } from '../contexts/taskstatus-context'
+
+const queryClient = new QueryClient()
 
 function CoreApp({ Component, pageProps }: AppProps) {
   return (
-    <SettingsContextProvider>
-      <SearchContextProvider>
-        <Layout>
-          <LibrariesContextProvider>
-            <ToastProvider>
-              <Component {...pageProps} />
-            </ToastProvider>
-          </LibrariesContextProvider>
-        </Layout>
-      </SearchContextProvider>
-    </SettingsContextProvider>
+    <QueryClientProvider client={queryClient}>
+      <EventsProvider>
+        <TaskStatusProvider>
+          <SettingsContextProvider>
+            <SearchContextProvider>
+              <Layout>
+                <LibrariesContextProvider>
+                  <ToastProvider>
+                    <Component {...pageProps} />
+                  </ToastProvider>
+                </LibrariesContextProvider>
+              </Layout>
+            </SearchContextProvider>
+          </SettingsContextProvider>
+        </TaskStatusProvider>
+      </EventsProvider>
+    </QueryClientProvider>
   )
 }
 

--- a/ui/src/pages/api/events/stream.ts
+++ b/ui/src/pages/api/events/stream.ts
@@ -1,0 +1,23 @@
+const apiPort = process.env.API_PORT || 3001
+
+export const config = {
+  runtime: 'edge',
+}
+
+export default async function handler() {
+  const { body } = await fetch(
+    `http://localhost:${apiPort}/api/events/stream`,
+    {
+      cache: 'no-cache',
+    },
+  )
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,6 +1204,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@faker-js/faker@npm:^9.6.0":
+  version: 9.6.0
+  resolution: "@faker-js/faker@npm:9.6.0"
+  checksum: 10c0/57f76aba8744ac5f588bfcf55e61ab6f1b61664f0d1cd6cc9d9ae5bf9376bdb48d867487ace638bee393de126257b7fe6ebd602c9efd3346e7ee10e8643f1cdc
+  languageName: node
+  linkType: hard
+
 "@floating-ui/core@npm:^1.5.3":
   version: 1.5.3
   resolution: "@floating-ui/core@npm:1.5.3"
@@ -2287,6 +2294,7 @@ __metadata:
     "@automock/jest": "npm:^2.1.0"
     "@eslint/eslintrc": "npm:^3.3.1"
     "@eslint/js": "npm:^9.23.0"
+    "@faker-js/faker": "npm:^9.6.0"
     "@maintainerr/contracts": "workspace:^"
     "@nestjs/cli": "npm:^11.0.5"
     "@nestjs/common": "npm:^11.0.12"
@@ -2298,6 +2306,9 @@ __metadata:
     "@nestjs/swagger": "npm:^11.1.0"
     "@nestjs/testing": "npm:^11.0.12"
     "@nestjs/typeorm": "npm:^11.0.0"
+    "@suites/di.nestjs": "npm:^3.0.1"
+    "@suites/doubles.jest": "npm:^3.0.1"
+    "@suites/unit": "npm:^3.0.1"
     "@types/express": "npm:^5.0.1"
     "@types/jest": "npm:^29.5.14"
     "@types/lodash": "npm:^4.17.15"
@@ -3657,6 +3668,78 @@ __metadata:
   version: 0.3.0
   resolution: "@standard-schema/utils@npm:0.3.0"
   checksum: 10c0/6eb74cd13e52d5fc74054df51e37d947ef53f3ab9e02c085665dcca3c38c60ece8d735cebbdf18fbb13c775fbcb9becb3f53109b0e092a63f0f7389ce0993fd0
+  languageName: node
+  linkType: hard
+
+"@suites/core.unit@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@suites/core.unit@npm:3.0.1"
+  dependencies:
+    "@suites/types.common": "npm:^3.0.0"
+    "@suites/types.di": "npm:^3.0.0"
+    lodash.isequal: "npm:^4.5.0"
+  checksum: 10c0/6ae023ede2d396393adbb451164a7eb0898c29e34eb475d7a3bec7cd0f308cf866aff9b90039f7b6ca505ae3240427dcce1a0d1f9205ae7809148893060c060f
+  languageName: node
+  linkType: hard
+
+"@suites/di.nestjs@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@suites/di.nestjs@npm:3.0.1"
+  dependencies:
+    "@suites/types.common": "npm:^3.0.0"
+    "@suites/types.di": "npm:^3.0.0"
+  peerDependencies:
+    "@nestjs/common": ">= 8.0"
+    reflect-metadata: <1.0.0
+  checksum: 10c0/1542fc58fe32cf1f040d6fc9d5b60c1bd7fe794fb8b4aa286b9d64fa7f43cb7b9c7feca422aa131f7ab5ceecae62fc92302dbfca6516649789ce89d87c31b9ee
+  languageName: node
+  linkType: hard
+
+"@suites/doubles.jest@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@suites/doubles.jest@npm:3.0.1"
+  dependencies:
+    "@suites/core.unit": "npm:^3.0.1"
+    "@suites/types.common": "npm:^3.0.0"
+    "@suites/types.doubles": "npm:^3.0.0"
+  peerDependencies:
+    jest: "> 26.0"
+  checksum: 10c0/42e79dc676a155948bd94150d72fadc22a84e727438f86ae3c8f0dacf8f125109f6f03fe4ff2de8ad116f5eeb790a1708916b150879975d0b41575ece23e9236
+  languageName: node
+  linkType: hard
+
+"@suites/types.common@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@suites/types.common@npm:3.0.0"
+  checksum: 10c0/103ea3fef3c8a2502565094b8005cb3a2cd549a5a911a969c5745c89e35b4cf2327667d92daa060c68a4577fad80da1d0939b2dd6c050b0ddbc0368bf5fcf876
+  languageName: node
+  linkType: hard
+
+"@suites/types.di@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@suites/types.di@npm:3.0.0"
+  dependencies:
+    "@suites/types.common": "npm:^3.0.0"
+  checksum: 10c0/447789340dc6a062b82d49512c2e606bdda76a586ae2334a42f3c8f798f60e59e7f0e7b364ab97ff7f1f6fb86c140315bc806c8acafed83449fede5ce1f29718
+  languageName: node
+  linkType: hard
+
+"@suites/types.doubles@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@suites/types.doubles@npm:3.0.0"
+  checksum: 10c0/694b10964daa6820715bd6b614dc581b5727c8ae320fb888eccf6290558a3e3d003c7d6f923ca741720e98276cfeb847ff7b72356441b31955f793cbc96d1116
+  languageName: node
+  linkType: hard
+
+"@suites/unit@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@suites/unit@npm:3.0.1"
+  dependencies:
+    "@suites/core.unit": "npm:^3.0.1"
+    "@suites/types.common": "npm:^3.0.0"
+    "@suites/types.di": "npm:^3.0.0"
+    "@suites/types.doubles": "npm:^3.0.0"
+  checksum: 10c0/e688bce8723929d260c7ab8340c119759dd5b17d1bb7273fa373d19a191284f21b413bfe3ed28e4a2835f943163a34f414ee796177c099b5519a5a0a47931238
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2348,6 +2348,8 @@ __metadata:
     "@tailwindcss/aspect-ratio": "npm:^0.4.2"
     "@tailwindcss/forms": "npm:^0.5.10"
     "@tailwindcss/typography": "npm:^0.5.16"
+    "@tanstack/eslint-plugin-query": "npm:^5.67.2"
+    "@tanstack/react-query": "npm:^5.67.3"
     "@types/lodash": "npm:^4.17.15"
     "@types/node": "npm:^22"
     "@types/react": "npm:^18"
@@ -2377,6 +2379,7 @@ __metadata:
     react-select: "npm:^5.10.1"
     react-toast-notifications: "npm:^2.5.1"
     react-transition-group: "npm:^4.4.5"
+    reconnecting-eventsource: "npm:^1.6.4"
     tailwindcss: "npm:^3.4.17"
     typescript: "npm:^5.8.2"
     yaml: "npm:^2.7.0"
@@ -3707,6 +3710,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/eslint-plugin-query@npm:^5.67.2":
+  version: 5.67.2
+  resolution: "@tanstack/eslint-plugin-query@npm:5.67.2"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^8.18.1"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  checksum: 10c0/646d6c8621d53c6eb171aea263c104a0d46eff5578da12d2fe009d6831a94e2d611e861a3d59d34b717a87b7768daa4e70fa00d7d8336441385ff9afb47e737c
+  languageName: node
+  linkType: hard
+
+"@tanstack/query-core@npm:5.67.3":
+  version: 5.67.3
+  resolution: "@tanstack/query-core@npm:5.67.3"
+  checksum: 10c0/3f681967cd457599c1e35bbef1467150a4b96837222c299876e6d80a835a4c86eba39fb1cbfc9c7f77bde6007ffbef7369fc93417196e9c61d49c4db6111e535
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^5.67.3":
+  version: 5.67.3
+  resolution: "@tanstack/react-query@npm:5.67.3"
+  dependencies:
+    "@tanstack/query-core": "npm:5.67.3"
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 10c0/160908bdac8ae0dc2fb3a94eba1252cbc2ba8a82cc18792ad4d3d60723ef36cf08d91d1a1824ce9ec84181f94379473475849208e82154a4469876605c65fef6
+  languageName: node
+  linkType: hard
+
 "@tootallnate/once@npm:1":
   version: 1.1.2
   resolution: "@tootallnate/once@npm:1.1.2"
@@ -4512,7 +4544,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.26.1":
+"@typescript-eslint/utils@npm:8.26.1, @typescript-eslint/utils@npm:^8.18.1":
   version: 8.26.1
   resolution: "@typescript-eslint/utils@npm:8.26.1"
   dependencies:
@@ -14259,6 +14291,13 @@ __metadata:
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
+  languageName: node
+  linkType: hard
+
+"reconnecting-eventsource@npm:^1.6.4":
+  version: 1.6.4
+  resolution: "reconnecting-eventsource@npm:1.6.4"
+  checksum: 10c0/ce760895524473e6b77e026ba9b62401a0f59bd60335c8f69d0c461b10f9f65d753a6c40843a3a1a67c28ee36341c2a6019632719e8df27a8b2110eb2486c32d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds rule & collection job progress above the version info, similar to *arrs but with actual bars! The run buttons now reflect the task running status and I have added an error toast if trying to run when already running (edge case if the status isn't available as the button is usually disabled).

![rules_progress](https://github.com/user-attachments/assets/eb8b085f-6cbb-435f-9cc4-16ce9309d45b)

This uses the event emitter from Nest.js to emit started, progress and finished events for both jobs. The events are sent down to the client using a new SSE endpoint and `@OnEvent` decorators. I've set this up to make adding new events and listening to them on the client super easy. One future use-case would be emitting events when media is added & removed from a collection and having the collection view be live updating.