### PR TITLE
feat: allow jellyfin users in jellyseerr integration

### DIFF
--- a/server/src/modules/api/jellyseerr-api/jellyseerr-api.service.ts
+++ b/server/src/modules/api/jellyseerr-api/jellyseerr-api.service.ts
@@ -56,6 +56,7 @@ interface JellyseerrUser {
   plexToken: string;
   plexId?: number;
   plexUsername: string;
+  jellyfinUsername?: string;
   userType: number;
   permissions: number;
   avatar: string;

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -910,7 +910,8 @@ export class RuleConstants {
         {
           id: 0,
           name: 'addUser',
-          humanName: 'Requested by user (Jellyfin, Emby, Plex or local username)',
+          humanName:
+            'Requested by user (Jellyfin, Emby, Plex or local username)',
           mediaType: MediaType.BOTH,
           type: RuleType.TEXT,
         }, //  returns username[]

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -910,7 +910,7 @@ export class RuleConstants {
         {
           id: 0,
           name: 'addUser',
-          humanName: 'Requested by user (Plex or local username)',
+          humanName: 'Requested by user (Jellyfin, or local username)',
           mediaType: MediaType.BOTH,
           type: RuleType.TEXT,
         }, //  returns username[]

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -910,7 +910,7 @@ export class RuleConstants {
         {
           id: 0,
           name: 'addUser',
-          humanName: 'Requested by user (Jellyfin, or local username)',
+          humanName: 'Requested by user (Jellyfin, Emby, Plex or local username)',
           mediaType: MediaType.BOTH,
           type: RuleType.TEXT,
         }, //  returns username[]

--- a/server/src/modules/rules/getter/jellyseerr-getter.service.ts
+++ b/server/src/modules/rules/getter/jellyseerr-getter.service.ts
@@ -116,6 +116,8 @@ export class JellyseerrGetterService {
                     if (includesSeason) {
                       if (request.requestedBy?.userType === 2) {
                         userNames.push(request.requestedBy?.username);
+                      } else if (request.requestedBy?.userType === 3) {
+                        userNames.push(request.requestedBy?.jellyfinUsername);
                       } else {
                         const user = plexUsers.find(
                           (u) => u.plexId === request.requestedBy?.plexId,
@@ -130,6 +132,8 @@ export class JellyseerrGetterService {
                     // for shows and movies, add every request user
                     if (request.requestedBy?.userType === 2) {
                       userNames.push(request.requestedBy?.username);
+                    } else if (request.requestedBy?.userType === 3) {
+                      userNames.push(request.requestedBy?.jellyfinUsername);
                     } else {
                       const user = plexUsers.find(
                         (u) => u.plexId === request.requestedBy?.plexId,

--- a/server/src/modules/rules/getter/jellyseerr-getter.service.ts
+++ b/server/src/modules/rules/getter/jellyseerr-getter.service.ts
@@ -116,7 +116,7 @@ export class JellyseerrGetterService {
                     if (includesSeason) {
                       if (request.requestedBy?.userType === 2) {
                         userNames.push(request.requestedBy?.username);
-                      } else if (request.requestedBy?.userType === 3) {
+                      } else if (request.requestedBy?.userType === 3 || request.requestedBy?.userType === 4) {
                         userNames.push(request.requestedBy?.jellyfinUsername);
                       } else {
                         const user = plexUsers.find(
@@ -132,7 +132,7 @@ export class JellyseerrGetterService {
                     // for shows and movies, add every request user
                     if (request.requestedBy?.userType === 2) {
                       userNames.push(request.requestedBy?.username);
-                    } else if (request.requestedBy?.userType === 3) {
+                    } else if (request.requestedBy?.userType === 3 || request.requestedBy?.userType === 4) {
                       userNames.push(request.requestedBy?.jellyfinUsername);
                     } else {
                       const user = plexUsers.find(

--- a/server/src/modules/rules/getter/jellyseerr-getter.service.ts
+++ b/server/src/modules/rules/getter/jellyseerr-getter.service.ts
@@ -116,7 +116,10 @@ export class JellyseerrGetterService {
                     if (includesSeason) {
                       if (request.requestedBy?.userType === 2) {
                         userNames.push(request.requestedBy?.username);
-                      } else if (request.requestedBy?.userType === 3 || request.requestedBy?.userType === 4) {
+                      } else if (
+                        request.requestedBy?.userType === 3 ||
+                        request.requestedBy?.userType === 4
+                      ) {
                         userNames.push(request.requestedBy?.jellyfinUsername);
                       } else {
                         const user = plexUsers.find(
@@ -132,7 +135,10 @@ export class JellyseerrGetterService {
                     // for shows and movies, add every request user
                     if (request.requestedBy?.userType === 2) {
                       userNames.push(request.requestedBy?.username);
-                    } else if (request.requestedBy?.userType === 3 || request.requestedBy?.userType === 4) {
+                    } else if (
+                      request.requestedBy?.userType === 3 ||
+                      request.requestedBy?.userType === 4
+                    ) {
                       userNames.push(request.requestedBy?.jellyfinUsername);
                     } else {
                       const user = plexUsers.find(


### PR DESCRIPTION
Adds the ability for Jellfin users signing into Jellyseerr to be matched in rules.

Resolves #1658 