### PR TITLE
fix: Reintroduce episode # in media card

### DIFF
--- a/ui/src/components/Common/MediaCard/index.tsx
+++ b/ui/src/components/Common/MediaCard/index.tsx
@@ -1,14 +1,14 @@
+import { DocumentAddIcon, DocumentRemoveIcon } from '@heroicons/react/solid'
 import React, { memo, useEffect, useState } from 'react'
 import Spinner from '../../../assets/spinner.svg'
-import Transition from '../Transition'
 import { useIsTouch } from '../../../hooks/useIsTouch'
-import CachedImage from '../CachedImage'
 import GetApiHandler from '../../../utils/ApiHandler'
-import Button from '../Button'
 import AddModal from '../../AddModal'
-import MediaModalContent from './MediaModal'
-import { DocumentAddIcon, DocumentRemoveIcon } from '@heroicons/react/solid'
 import RemoveFromCollectionBtn from '../../Collection/CollectionDetail/RemoveFromCollectionBtn'
+import Button from '../Button'
+import CachedImage from '../CachedImage'
+import Transition from '../Transition'
+import MediaModalContent from './MediaModal'
 
 interface IMediaCard {
   id: number
@@ -291,16 +291,20 @@ const MediaCard: React.FC<IMediaCard> = ({
                     >
                       {title}
                     </h1>
-                    <div
-                      className="whitespace-normal text-xs"
-                      style={{
-                        WebkitLineClamp: 5,
-                        display: '-webkit-box',
-                        overflow: 'hidden',
-                        WebkitBoxOrient: 'vertical',
-                        wordBreak: 'break-word',
-                      }}
-                    ></div>
+                    {mediaType == 'episode' && (
+                      <div
+                        className="whitespace-normal text-xs"
+                        style={{
+                          WebkitLineClamp: 5,
+                          display: '-webkit-box',
+                          overflow: 'hidden',
+                          WebkitBoxOrient: 'vertical',
+                          wordBreak: 'break-word',
+                        }}
+                      >
+                        {summary}
+                      </div>
+                    )}
 
                     {!collectionPage ? (
                       <div>


### PR DESCRIPTION
### Description

This re-adds the episode number to the media card. This was removed in #1505.

### Related issue

Fixes #1686

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code.
- [x] I have linted and formatted my code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

### How to test

Please describe the steps to test your changes, including any setup required.

1. Create an episodes rule and run it
2. Go to the collection and hover over the media card
3. The episode number should be displayed

### Additional context

![image](https://github.com/user-attachments/assets/f803e7bc-bef8-4fe4-a26d-3d35820342ff)

