### PR TITLE
fix: force reset Overseerr throwing exception

### DIFF
--- a/server/src/modules/collections/collection-handler.spec.ts
+++ b/server/src/modules/collections/collection-handler.spec.ts
@@ -2,11 +2,15 @@ import { Mocked, TestBed } from '@suites/unit';
 import {
   createCollection,
   createCollectionMedia,
+  createCollectionMediaWithPlexData,
   createPlexLibraries,
 } from '../../../test/utils/data';
 import { RadarrActionHandler } from '../actions/radarr-action-handler';
 import { SonarrActionHandler } from '../actions/sonarr-action-handler';
+import { OverseerrApiService } from '../api/overseerr-api/overseerr-api.service';
+import { EPlexDataType } from '../api/plex-api/enums/plex-data-type-enum';
 import { PlexApiService } from '../api/plex-api/plex-api.service';
+import { SettingsService } from '../settings/settings.service';
 import { CollectionHandler } from './collection-handler';
 import { CollectionsService } from './collections.service';
 import { ServarrAction } from './interfaces/collection.interface';
@@ -17,6 +21,8 @@ describe('CollectionHandler', () => {
   let collectionsService: Mocked<CollectionsService>;
   let radarrActionHandler: Mocked<RadarrActionHandler>;
   let sonarrActionHandler: Mocked<SonarrActionHandler>;
+  let overseerrApi: Mocked<OverseerrApiService>;
+  let settings: Mocked<SettingsService>;
 
   beforeEach(async () => {
     const { unit, unitRef } =
@@ -27,6 +33,25 @@ describe('CollectionHandler', () => {
     collectionsService = unitRef.get(CollectionsService);
     radarrActionHandler = unitRef.get(RadarrActionHandler);
     sonarrActionHandler = unitRef.get(SonarrActionHandler);
+    overseerrApi = unitRef.get(OverseerrApiService);
+    settings = unitRef.get(SettingsService);
+  });
+
+  it('should do nothing if action is DO_NOTHING', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DO_NOTHING,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'movie');
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+      }),
+    );
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(collectionsService.removeFromCollection).not.toHaveBeenCalled();
   });
 
   it('should delete from disk', async () => {
@@ -85,5 +110,161 @@ describe('CollectionHandler', () => {
 
     expect(collectionsService.removeFromCollection).toHaveBeenCalledTimes(1);
     expect(sonarrActionHandler.handleAction).toHaveBeenCalled();
+  });
+
+  it('should call removeSeasonRequest for seasons', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      forceOverseerr: true,
+      type: EPlexDataType.SEASONS,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'season',
+    );
+
+    settings.overseerrConfigured.mockReturnValue(true);
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(overseerrApi.removeSeasonRequest).toHaveBeenCalledWith(
+      collectionMedia.tmdbId,
+      collectionMedia.plexData.index,
+    );
+    expect(overseerrApi.removeSeasonRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call removeSeasonRequest for episodes', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      forceOverseerr: true,
+      type: EPlexDataType.EPISODES,
+    });
+    const collectionMedia = createCollectionMediaWithPlexData(
+      collection,
+      'show',
+    );
+
+    settings.overseerrConfigured.mockReturnValue(true);
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+    plexApi.getMetadata.mockResolvedValue(collectionMedia.plexData);
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(overseerrApi.removeSeasonRequest).toHaveBeenCalledWith(
+      collectionMedia.tmdbId,
+      collectionMedia.plexData.parentIndex,
+    );
+    expect(overseerrApi.removeSeasonRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call removeMediaByTmdbId for movies', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      forceOverseerr: true,
+      type: EPlexDataType.MOVIES,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'movie');
+
+    settings.overseerrConfigured.mockReturnValue(true);
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+        type: 'movie',
+      }),
+    );
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(overseerrApi.removeMediaByTmdbId).toHaveBeenCalledWith(
+      collectionMedia.tmdbId,
+      'movie',
+    );
+    expect(overseerrApi.removeMediaByTmdbId).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call removeMediaByTmdbId for shows', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      forceOverseerr: true,
+      type: EPlexDataType.SHOWS,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'show');
+
+    settings.overseerrConfigured.mockReturnValue(true);
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+        type: 'show',
+      }),
+    );
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(overseerrApi.removeMediaByTmdbId).toHaveBeenCalledWith(
+      collectionMedia.tmdbId,
+      'tv',
+    );
+    expect(overseerrApi.removeMediaByTmdbId).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call OverseerrApiService if forceOverseerr is false', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      forceOverseerr: false,
+      type: EPlexDataType.MOVIES,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'movie');
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+        type: 'movie',
+      }),
+    );
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(overseerrApi.removeMediaByTmdbId).not.toHaveBeenCalled();
+    expect(overseerrApi.removeSeasonRequest).not.toHaveBeenCalled();
+  });
+
+  it('should not call OverseerrApiService if Overseerr is not configured', async () => {
+    const collection = createCollection({
+      arrAction: ServarrAction.DELETE,
+      forceOverseerr: false,
+      type: EPlexDataType.MOVIES,
+    });
+    const collectionMedia = createCollectionMedia(collection, 'movie');
+
+    settings.overseerrConfigured.mockReturnValue(false);
+
+    plexApi.getLibraries.mockResolvedValue(
+      createPlexLibraries({
+        key: collection.libraryId.toString(),
+        type: 'movie',
+      }),
+    );
+
+    await collectionHandler.handleMedia(collection, collectionMedia);
+
+    expect(overseerrApi.removeMediaByTmdbId).not.toHaveBeenCalled();
+    expect(overseerrApi.removeSeasonRequest).not.toHaveBeenCalled();
   });
 });

--- a/server/src/modules/collections/collection-handler.ts
+++ b/server/src/modules/collections/collection-handler.ts
@@ -29,8 +29,6 @@ export class CollectionHandler {
       return;
     }
 
-    const plexData: PlexMetadata = undefined;
-
     const plexLibrary = (await this.plexApi.getLibraries()).find(
       (e) => +e.key === +collection.libraryId,
     );
@@ -77,21 +75,30 @@ export class CollectionHandler {
       if (this.settings.overseerrConfigured() && collection.forceOverseerr) {
         switch (collection.type) {
           case EPlexDataType.SEASONS:
+            const plexDataSeason: PlexMetadata = await this.plexApi.getMetadata(
+              media.plexId.toString(),
+            );
+
             await this.overseerrApi.removeSeasonRequest(
               media.tmdbId,
-              plexData.index,
+              plexDataSeason.index,
             );
+
             this.logger.log(
-              `[Overseerr] Removed request of season ${plexData.index} from show with tmdbid '${media.tmdbId}'`,
+              `[Overseerr] Removed request of season ${plexDataSeason.index} from show with tmdbid '${media.tmdbId}'`,
             );
             break;
           case EPlexDataType.EPISODES:
+            const plexDataEpisode: PlexMetadata =
+              await this.plexApi.getMetadata(media.plexId.toString());
+
             await this.overseerrApi.removeSeasonRequest(
               media.tmdbId,
-              plexData.parentIndex,
+              plexDataEpisode.parentIndex,
             );
+
             this.logger.log(
-              `[Overseerr] Removed request of season ${plexData.parentIndex} from show with tmdbid '${media.tmdbId}'. Because episode ${plexData.index} was removed.'`,
+              `[Overseerr] Removed request of season ${plexDataEpisode.parentIndex} from show with tmdbid '${media.tmdbId}'. Because episode ${plexDataEpisode.index} was removed.'`,
             );
             break;
           default:


### PR DESCRIPTION
### Description

I spotted `plexData` wasn't being set whilst refactoring, another L for having strict disabled. This bug was introduced in [this commit](https://github.com/jorenn92/Maintainerr/pull/1659/files#diff-05876c881d79d411f925e4a5d613de143512ef618b0c272a0bfdab66667b932bL255-L269), has not made it into a release yet.