### PR TITLE
feat: Save rule results against collection log

### DIFF
--- a/packages/contracts/src/collections/index.ts
+++ b/packages/contracts/src/collections/index.ts
@@ -1,0 +1,1 @@
+export * from './logs'

--- a/packages/contracts/src/collections/logs.ts
+++ b/packages/contracts/src/collections/logs.ts
@@ -1,0 +1,63 @@
+import { IComparisonStatistics } from '../rules/rule'
+
+export type CollectionLogDto = {
+  timestamp: Date
+  message: string
+} & (
+  | {
+      type: ECollectionLogType.MEDIA
+      meta:
+        | CollectionLogMetaMediaAddedByRule
+        | CollectionLogMetaMediaRemovedByRule
+        | CollectionLogMetaMediaAddedManually
+        | CollectionLogMetaMediaRemovedManually
+    }
+  | {
+      type: ECollectionLogType.COLLECTION
+      meta: null
+    }
+  | {
+      type: ECollectionLogType.RULES
+      meta: null
+    }
+)
+
+export enum ECollectionLogType {
+  COLLECTION,
+  MEDIA,
+  RULES,
+}
+
+export const isMetaActionedByRule = (
+  type: CollectionLogMeta,
+): type is
+  | CollectionLogMetaMediaAddedByRule
+  | CollectionLogMetaMediaRemovedByRule => {
+  return (
+    type.type === 'media_added_by_rule' || type.type === 'media_removed_by_rule'
+  )
+}
+
+export type CollectionLogMeta =
+  | CollectionLogMetaMediaAddedByRule
+  | CollectionLogMetaMediaRemovedByRule
+  | CollectionLogMetaMediaAddedManually
+  | CollectionLogMetaMediaRemovedManually
+
+export type CollectionLogMetaMediaAddedByRule = {
+  type: 'media_added_by_rule'
+  data: IComparisonStatistics
+}
+
+export type CollectionLogMetaMediaRemovedByRule = {
+  type: 'media_removed_by_rule'
+  data: IComparisonStatistics
+}
+
+export type CollectionLogMetaMediaAddedManually = {
+  type: 'media_added_manually'
+}
+
+export type CollectionLogMetaMediaRemovedManually = {
+  type: 'media_removed_manually'
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,6 @@
 export * from './app'
+export * from './collections'
 export * from './events'
+export * from './rules'
 export * from './settings/logs'
 export * from './tasks'

--- a/packages/contracts/src/rules/index.ts
+++ b/packages/contracts/src/rules/index.ts
@@ -1,0 +1,1 @@
+export * from './rule'

--- a/packages/contracts/src/rules/rule.ts
+++ b/packages/contracts/src/rules/rule.ts
@@ -1,0 +1,31 @@
+export interface IComparisonStatistics {
+  plexId: number
+  result: boolean
+  sectionResults: ISectionComparisonResults[]
+}
+
+export interface ISectionComparisonResults {
+  id: number
+  result: boolean
+  operator?: string
+  ruleResults: IRuleComparisonResult[]
+}
+
+export interface IRuleComparisonResult {
+  firstValueName: string
+  firstValue: RuleValueType
+  secondValueName: string
+  secondValue: RuleValueType
+  action: string
+  operator?: string
+  result: boolean
+}
+
+export type RuleValueType =
+  | number
+  | Date
+  | string
+  | boolean
+  | number[]
+  | string[]
+  | null

--- a/server/src/database/migrations/1741477145504-Add_collection_log_meta.ts
+++ b/server/src/database/migrations/1741477145504-Add_collection_log_meta.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCollectionLogMeta1741477145504 implements MigrationInterface {
+  name = 'AddCollectionLogMeta1741477145504';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE "collection_log" ADD COLUMN "meta" text',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "collection_log" DROP "meta"`);
+  }
+}

--- a/server/src/modules/collections/collections.controller.ts
+++ b/server/src/modules/collections/collections.controller.ts
@@ -1,3 +1,4 @@
+import { ECollectionLogType } from '@maintainerr/contracts';
 import {
   Body,
   Controller,
@@ -11,11 +12,10 @@ import {
   Put,
   Query,
 } from '@nestjs/common';
-import { ECollectionLogType } from '../collections/entities/collection_log.entities';
 import { CollectionWorkerService } from './collection-worker.service';
 import { CollectionsService } from './collections.service';
 import {
-  AddCollectionMedia,
+  AddRemoveCollectionMedia,
   IAlterableMediaDto,
 } from './interfaces/collection-media.interface';
 
@@ -37,7 +37,7 @@ export class CollectionsController {
     @Body()
     request: {
       collectionId: number;
-      media: AddCollectionMedia[];
+      media: AddRemoveCollectionMedia[];
       manual?: boolean;
     },
   ) {

--- a/server/src/modules/collections/collections.service.ts
+++ b/server/src/modules/collections/collections.service.ts
@@ -2,10 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, LessThan, Repository } from 'typeorm';
 
-import {
-  CollectionLog,
-  ECollectionLogType,
-} from '../../modules/collections/entities/collection_log.entities';
+import { CollectionLogMeta, ECollectionLogType } from '@maintainerr/contracts';
+import { CollectionLog } from '../../modules/collections/entities/collection_log.entities';
 import { BasicResponseDto } from '../api/plex-api/dto/basic-response.dto';
 import {
   CreateUpdateCollection,
@@ -26,7 +24,7 @@ import {
   CollectionMediaWithPlexData,
 } from './entities/collection_media.entities';
 import {
-  AddCollectionMedia,
+  AddRemoveCollectionMedia,
   IAlterableMediaDto,
 } from './interfaces/collection-media.interface';
 import { ICollection } from './interfaces/collection.interface';
@@ -319,7 +317,7 @@ export class CollectionsService {
 
   async createCollectionWithChildren(
     collection: ICollection,
-    media?: AddCollectionMedia[],
+    media?: AddRemoveCollectionMedia[],
   ): Promise<{
     plexCollection: PlexCollection;
     dbCollection: addCollectionDbResponse;
@@ -502,7 +500,7 @@ export class CollectionsService {
   async MediaCollectionActionWithContext(
     collectionDbId: number,
     context: IAlterableMediaDto,
-    media: AddCollectionMedia,
+    media: AddRemoveCollectionMedia,
     action: 'add' | 'remove',
   ): Promise<Collection> {
     const collection =
@@ -513,12 +511,12 @@ export class CollectionsService {
         : undefined;
 
     // get media
-    const handleMedia: AddCollectionMedia[] =
+    const handleMedia: AddRemoveCollectionMedia[] =
       (await this.plexApi.getAllIdsForContextAction(
         collection ? collection.type : undefined,
         context,
         media,
-      )) as unknown as AddCollectionMedia[];
+      )) as unknown as AddRemoveCollectionMedia[];
 
     if (handleMedia) {
       if (action === 'add') {
@@ -535,7 +533,7 @@ export class CollectionsService {
 
   async addToCollection(
     collectionDbId: number,
-    media: AddCollectionMedia[],
+    media: AddRemoveCollectionMedia[],
     manual = false,
   ): Promise<Collection> {
     try {
@@ -595,6 +593,7 @@ export class CollectionsService {
               { plexId: +collection.plexId, dbId: collection.id },
               childMedia.plexId,
               manual,
+              childMedia.reason,
             );
           }
         }
@@ -612,7 +611,7 @@ export class CollectionsService {
 
   async removeFromCollection(
     collectionDbId: number,
-    media: AddCollectionMedia[],
+    media: AddRemoveCollectionMedia[],
   ) {
     try {
       let collection = await this.collectionRepo.findOne({
@@ -633,6 +632,7 @@ export class CollectionsService {
             await this.removeChildFromCollection(
               { plexId: +collection.plexId, dbId: collection.id },
               childMedia.plexId,
+              childMedia.reason,
             );
 
             collectionMedia = collectionMedia.filter(
@@ -670,7 +670,7 @@ export class CollectionsService {
     }
   }
 
-  async removeFromAllCollections(media: AddCollectionMedia[]) {
+  async removeFromAllCollections(media: AddRemoveCollectionMedia[]) {
     try {
       const collection = await this.collectionRepo.find();
       collection.forEach((c) => this.removeFromCollection(c.id, media));
@@ -791,6 +791,7 @@ export class CollectionsService {
     collectionIds: { plexId: number; dbId: number },
     childId: number,
     manual = false,
+    logMeta?: CollectionLogMeta,
   ) {
     try {
       this.infoLogger(`Adding media with id ${childId} to collection..`);
@@ -833,7 +834,12 @@ export class CollectionsService {
           .execute();
 
         // log record
-        this.CollectionLogRecordForChild(childId, collectionIds.dbId, 'add');
+        this.CollectionLogRecordForChild(
+          childId,
+          collectionIds.dbId,
+          'add',
+          logMeta,
+        );
       } else {
         this.logger.warn(
           `Couldn't add media to collection: 
@@ -852,6 +858,7 @@ export class CollectionsService {
     plexId: number,
     collectionId: number,
     type: 'add' | 'remove' | 'handle' | 'exclude' | 'include',
+    logMeta?: CollectionLogMeta,
   ) {
     // log record
     const plexData = await this.plexApi.getMetadata(plexId.toString()); // fetch data from cache
@@ -868,6 +875,7 @@ export class CollectionsService {
         { id: collectionId } as Collection,
         `${type === 'add' ? 'Added' : type === 'handle' ? 'Successfully handled' : type === 'exclude' ? 'Added a specific exclusion for' : type === 'include' ? 'Removed specific exclusion of' : 'Removed'} "${subject}"`,
         ECollectionLogType.MEDIA,
+        logMeta,
       );
     }
   }
@@ -875,6 +883,7 @@ export class CollectionsService {
   private async removeChildFromCollection(
     collectionIds: { plexId: number; dbId: number },
     childId: number,
+    logMeta?: CollectionLogMeta,
   ) {
     try {
       this.infoLogger(`Removing media with id ${childId} from collection..`);
@@ -900,7 +909,12 @@ export class CollectionsService {
           ])
           .execute();
 
-        this.CollectionLogRecordForChild(childId, collectionIds.dbId, 'remove');
+        this.CollectionLogRecordForChild(
+          childId,
+          collectionIds.dbId,
+          'remove',
+          logMeta,
+        );
       } else {
         this.infoLogger(
           `Couldn't remove media from collection: ` + responseColl.message,
@@ -1111,6 +1125,7 @@ export class CollectionsService {
     collection: Collection,
     message: string,
     type: ECollectionLogType,
+    meta?: CollectionLogMeta,
   ) {
     await this.connection
       .createQueryBuilder()
@@ -1118,10 +1133,11 @@ export class CollectionsService {
       .into(CollectionLog)
       .values([
         {
-          collection: collection,
+          collection,
           timestamp: new Date(),
-          message: message,
-          type: type,
+          message,
+          type,
+          meta,
         },
       ])
       .execute();

--- a/server/src/modules/collections/entities/collection_log.entities.ts
+++ b/server/src/modules/collections/entities/collection_log.entities.ts
@@ -1,4 +1,4 @@
-import { Collection } from '../../collections/entities/collection.entities';
+import { CollectionLogMeta, ECollectionLogType } from '@maintainerr/contracts';
 import {
   Column,
   Entity,
@@ -6,12 +6,7 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
-
-export enum ECollectionLogType {
-  COLLECTION,
-  MEDIA,
-  RULES,
-}
+import { Collection } from '../../collections/entities/collection.entities';
 
 @Entity()
 @Index('idx_collection_log_collection_id', ['collection'])
@@ -36,4 +31,7 @@ export class CollectionLog {
 
   @Column({ nullable: true })
   type: ECollectionLogType;
+
+  @Column('simple-json', { nullable: true })
+  meta: CollectionLogMeta;
 }

--- a/server/src/modules/collections/interfaces/collection-media.interface.ts
+++ b/server/src/modules/collections/interfaces/collection-media.interface.ts
@@ -1,3 +1,4 @@
+import { CollectionLogMeta } from '@maintainerr/contracts';
 import { EPlexDataType } from '../../api/plex-api/enums/plex-data-type-enum';
 
 export interface ICollectionMedia {
@@ -9,8 +10,9 @@ export interface ICollectionMedia {
   addDate: Date;
 }
 
-export interface AddCollectionMedia {
+export interface AddRemoveCollectionMedia {
   plexId: number;
+  reason?: CollectionLogMeta;
 }
 
 export interface IAlterableMediaDto {

--- a/server/src/modules/rules/constants/rules.constants.ts
+++ b/server/src/modules/rules/constants/rules.constants.ts
@@ -110,15 +110,6 @@ export class RuleType {
   }
 }
 
-export type RuleValueType =
-  | number
-  | Date
-  | string
-  | boolean
-  | number[]
-  | string[]
-  | null;
-
 export interface Property {
   id: number;
   name: string;

--- a/server/src/modules/rules/getter/getter.service.ts
+++ b/server/src/modules/rules/getter/getter.service.ts
@@ -1,14 +1,15 @@
+import { RuleValueType } from '@maintainerr/contracts';
 import { Injectable } from '@nestjs/common';
 import { PlexLibraryItem } from '../../../modules/api/plex-api/interfaces/library.interfaces';
-import { Application, RuleValueType } from '../constants/rules.constants';
+import { EPlexDataType } from '../../api/plex-api/enums/plex-data-type-enum';
+import { Application } from '../constants/rules.constants';
+import { RulesDto } from '../dtos/rules.dto';
+import { JellyseerrGetterService } from './jellyseerr-getter.service';
 import { OverseerrGetterService } from './overseerr-getter.service';
 import { PlexGetterService } from './plex-getter.service';
 import { RadarrGetterService } from './radarr-getter.service';
 import { SonarrGetterService } from './sonarr-getter.service';
-import { RulesDto } from '../dtos/rules.dto';
-import { EPlexDataType } from '../../api/plex-api/enums/plex-data-type-enum';
 import { TautulliGetterService } from './tautulli-getter.service';
-import { JellyseerrGetterService } from './jellyseerr-getter.service';
 
 @Injectable()
 export class ValueGetterService {

--- a/server/src/modules/rules/getter/plex-getter.service.ts
+++ b/server/src/modules/rules/getter/plex-getter.service.ts
@@ -1,3 +1,4 @@
+import { RuleValueType } from '@maintainerr/contracts';
 import { Injectable, Logger } from '@nestjs/common';
 import {
   PlexLibraryItem,
@@ -11,7 +12,6 @@ import {
   Application,
   Property,
   RuleConstants,
-  RuleValueType,
 } from '../constants/rules.constants';
 import { RulesDto } from '../dtos/rules.dto';
 

--- a/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -1,3 +1,8 @@
+import {
+  IComparisonStatistics,
+  IRuleComparisonResult,
+  RuleValueType,
+} from '@maintainerr/contracts';
 import { Injectable, Logger } from '@nestjs/common';
 import _ from 'lodash';
 import { EPlexDataType } from '../../api/plex-api/enums/plex-data-type-enum';
@@ -7,35 +12,11 @@ import {
   RuleOperators,
   RulePossibility,
   RuleType,
-  RuleValueType,
 } from '../constants/rules.constants';
 import { RuleDto } from '../dtos/rule.dto';
 import { RuleDbDto } from '../dtos/ruleDb.dto';
 import { RulesDto } from '../dtos/rules.dto';
 import { ValueGetterService } from '../getter/getter.service';
-
-interface IComparisonStatistics {
-  plexId: number;
-  result: boolean;
-  sectionResults: ISectionComparisonResults[];
-}
-
-interface ISectionComparisonResults {
-  id: number;
-  result: boolean;
-  operator?: string;
-  ruleResults: IRuleComparisonResult[];
-}
-
-interface IRuleComparisonResult {
-  firstValueName: string;
-  firstValue: RuleValueType;
-  secondValueName: string;
-  secondValue: RuleValueType;
-  action: string;
-  operator?: string;
-  result: boolean;
-}
 
 interface IComparatorReturnValue {
   stats: IComparisonStatistics[];
@@ -66,7 +47,6 @@ export class RuleComparatorService {
   plexDataType: EPlexDataType;
   statistics: IComparisonStatistics[];
   statisticWorker: IRuleComparisonResult[];
-  enabledStats: boolean;
 
   constructor(
     private readonly valueGetter: ValueGetterService,
@@ -76,14 +56,12 @@ export class RuleComparatorService {
   public async executeRulesWithData(
     rulegroup: RulesDto,
     plexData: PlexLibraryItem[],
-    withStats = false,
     onRuleProgress?: (processingRule: number) => void,
   ): Promise<IComparatorReturnValue> {
     try {
       // prepare
       this.plexData = plexData;
       this.plexDataType = rulegroup.dataType ? rulegroup.dataType : undefined;
-      this.enabledStats = withStats;
       this.workerData = [];
       this.resultData = [];
       this.statistics = [];
@@ -93,7 +71,6 @@ export class RuleComparatorService {
       let currentSection = 0;
       let sectionActionAnd = false;
 
-      // prepare statistics if needed
       this.prepareStatistics();
 
       let ruleNumber = 0;
@@ -114,7 +91,7 @@ export class RuleComparatorService {
           // execute and store in work array
           await this.executeRule(parsedRule, rulegroup);
         } else {
-          // set the stat results of the completed section, if needed
+          // set the stat results of the completed section
           this.setStatisticSectionResults();
 
           // handle section action
@@ -134,14 +111,11 @@ export class RuleComparatorService {
           currentSection = (rule as RuleDbDto).section;
         }
       }
-      // set the stat results of the last section, if needed
+      // set the stat results of the last section
       this.setStatisticSectionResults();
 
       // handle last section
       this.handleSectionAction(sectionActionAnd);
-
-      // update statistics results when needed
-      this.updateStatisticResults();
 
       // update result for matched media
       this.statistics.forEach((el) => {
@@ -159,37 +133,31 @@ export class RuleComparatorService {
   }
 
   private updateStatisticResults() {
-    if (this.enabledStats) {
-      this.statistics.forEach((el) => {
-        el.result = this.resultData.some((i) => +i.ratingKey === +el.plexId);
-      });
-    }
+    this.statistics.forEach((el) => {
+      el.result = this.resultData.some((i) => +i.ratingKey === +el.plexId);
+    });
   }
 
   private setStatisticSectionResults() {
     // add the result of the last section. If media is in workerData, section = true.
-    if (this.enabledStats) {
-      this.statistics.forEach((stat) => {
-        if (this.workerData.find((el) => +el.ratingKey === +stat.plexId)) {
-          stat.sectionResults[stat.sectionResults.length - 1].result = true;
-        } else {
-          stat.sectionResults[stat.sectionResults.length - 1].result = false;
-        }
-      });
-    }
+    this.statistics.forEach((stat) => {
+      if (this.workerData.find((el) => +el.ratingKey === +stat.plexId)) {
+        stat.sectionResults[stat.sectionResults.length - 1].result = true;
+      } else {
+        stat.sectionResults[stat.sectionResults.length - 1].result = false;
+      }
+    });
   }
 
   private addSectionToStatistics(id: number, isAND: boolean) {
-    if (this.enabledStats) {
-      this.statistics.forEach((data) => {
-        data.sectionResults.push({
-          id: id,
-          result: undefined,
-          operator: isAND ? 'AND' : 'OR',
-          ruleResults: [],
-        });
+    this.statistics.forEach((data) => {
+      data.sectionResults.push({
+        id: id,
+        result: undefined,
+        operator: isAND ? 'AND' : 'OR',
+        ruleResults: [],
       });
-    }
+    });
   }
 
   private async executeRule(rule: RuleDto, ruleGroup: RulesDto) {
@@ -316,21 +284,19 @@ export class RuleComparatorService {
   }
 
   private prepareStatistics() {
-    if (this.enabledStats) {
-      this.plexData.forEach((data) => {
-        this.statistics.push({
-          plexId: +data.ratingKey,
-          result: false,
-          sectionResults: [
-            {
-              id: 0,
-              result: undefined,
-              ruleResults: [],
-            },
-          ],
-        });
+    this.plexData.forEach((data) => {
+      this.statistics.push({
+        plexId: +data.ratingKey,
+        result: false,
+        sectionResults: [
+          {
+            id: 0,
+            result: undefined,
+            ruleResults: [],
+          },
+        ],
       });
-    }
+    });
   }
 
   private addStatistictoParent(
@@ -340,40 +306,38 @@ export class RuleComparatorService {
     plexId: number,
     result: boolean,
   ) {
-    if (this.enabledStats) {
-      const index = this.statistics.findIndex((el) => +el.plexId === +plexId);
-      const sectionIndex = this.statistics[index].sectionResults.length - 1;
+    const index = this.statistics.findIndex((el) => +el.plexId === +plexId);
+    const sectionIndex = this.statistics[index].sectionResults.length - 1;
 
-      // push result to currently last section
-      this.statistics[index].sectionResults[sectionIndex].ruleResults.push({
-        operator:
-          rule.operator === null || rule.operator === undefined
-            ? RuleOperators[1]
-            : RuleOperators[rule.operator],
-        action: RulePossibility[rule.action].toLowerCase(),
-        firstValueName: this.ruleConstanstService.getValueHumanName(
-          rule.firstVal,
-        ),
-        firstValue: firstVal,
-        secondValueName: rule.lastVal
-          ? this.ruleConstanstService.getValueHumanName(rule.lastVal)
-          : this.ruleConstanstService.getCustomValueIdentifier(rule.customVal)
-              .type,
-        secondValue: secondVal,
-        result: result,
-      });
+    // push result to currently last section
+    this.statistics[index].sectionResults[sectionIndex].ruleResults.push({
+      operator:
+        rule.operator === null || rule.operator === undefined
+          ? RuleOperators[1]
+          : RuleOperators[rule.operator],
+      action: RulePossibility[rule.action].toLowerCase(),
+      firstValueName: this.ruleConstanstService.getValueHumanName(
+        rule.firstVal,
+      ),
+      firstValue: firstVal,
+      secondValueName: rule.lastVal
+        ? this.ruleConstanstService.getValueHumanName(rule.lastVal)
+        : this.ruleConstanstService.getCustomValueIdentifier(rule.customVal)
+            .type,
+      secondValue: secondVal,
+      result: result,
+    });
 
-      // If it's the first rule of a section (but not the first one) then add the operator to the sectionResult
-      if (
-        index > 0 &&
-        this.statistics[index].sectionResults[sectionIndex].ruleResults
-          .length === 1
-      ) {
-        this.statistics[index].sectionResults[sectionIndex].operator =
-          rule.operator === null || rule.operator === undefined
-            ? RuleOperators[1]
-            : RuleOperators[rule.operator];
-      }
+    // If it's the first rule of a section (but not the first one) then add the operator to the sectionResult
+    if (
+      index > 0 &&
+      this.statistics[index].sectionResults[sectionIndex].ruleResults.length ===
+        1
+    ) {
+      this.statistics[index].sectionResults[sectionIndex].operator =
+        rule.operator === null || rule.operator === undefined
+          ? RuleOperators[1]
+          : RuleOperators[rule.operator];
     }
   }
 

--- a/server/src/modules/rules/rules.service.ts
+++ b/server/src/modules/rules/rules.service.ts
@@ -1,3 +1,4 @@
+import { ECollectionLogType } from '@maintainerr/contracts';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import axios from 'axios';
@@ -9,9 +10,8 @@ import { PlexLibraryItem } from '../api/plex-api/interfaces/library.interfaces';
 import { PlexApiService } from '../api/plex-api/plex-api.service';
 import { CollectionsService } from '../collections/collections.service';
 import { Collection } from '../collections/entities/collection.entities';
-import { ECollectionLogType } from '../collections/entities/collection_log.entities';
 import { CollectionMedia } from '../collections/entities/collection_media.entities';
-import { AddCollectionMedia } from '../collections/interfaces/collection-media.interface';
+import { AddRemoveCollectionMedia } from '../collections/interfaces/collection-media.interface';
 import { RadarrSettings } from '../settings/entities/radarr_settings.entities';
 import { Settings } from '../settings/entities/settings.entities';
 import { SonarrSettings } from '../settings/entities/sonarr_settings.entities';
@@ -436,7 +436,7 @@ export class RulesService {
     }
   }
   async setExclusion(data: ExclusionContextDto) {
-    let handleMedia: AddCollectionMedia[] = [];
+    let handleMedia: AddRemoveCollectionMedia[] = [];
 
     if (data.collectionId) {
       const group = await this.ruleGroupRepository.findOne({
@@ -451,7 +451,7 @@ export class RulesService {
           ? data.context
           : { type: group.dataType, id: data.mediaId },
         { plexId: data.mediaId },
-      )) as unknown as AddCollectionMedia[];
+      )) as unknown as AddRemoveCollectionMedia[];
       data.ruleGroupId = group.id;
     } else {
       // get type from metadata
@@ -463,7 +463,7 @@ export class RulesService {
         undefined,
         data.context ? data.context : { type: type, id: data.mediaId },
         { plexId: data.mediaId },
-      )) as unknown as AddCollectionMedia[];
+      )) as unknown as AddRemoveCollectionMedia[];
     }
     try {
       // add all items
@@ -570,7 +570,7 @@ export class RulesService {
   }
 
   async removeExclusionWitData(data: ExclusionContextDto) {
-    let handleMedia: AddCollectionMedia[] = [];
+    let handleMedia: AddRemoveCollectionMedia[] = [];
 
     if (data.collectionId) {
       const group = await this.ruleGroupRepository.findOne({
@@ -587,14 +587,14 @@ export class RulesService {
           ? data.context
           : { type: group.libraryId, id: data.mediaId },
         { plexId: data.mediaId },
-      )) as unknown as AddCollectionMedia[];
+      )) as unknown as AddRemoveCollectionMedia[];
     } else {
       // get type from metadata
       handleMedia = (await this.plexApi.getAllIdsForContextAction(
         undefined,
         { type: data.context.type, id: data.context.id },
         { plexId: data.mediaId },
-      )) as unknown as AddCollectionMedia[];
+      )) as unknown as AddRemoveCollectionMedia[];
     }
 
     try {
@@ -636,7 +636,7 @@ export class RulesService {
 
   async removeAllExclusion(plexId: number) {
     // get type from metadata
-    let handleMedia: AddCollectionMedia[] = [];
+    let handleMedia: AddRemoveCollectionMedia[] = [];
 
     const metaData = await this.plexApi.getMetadata(plexId.toString());
     const type =
@@ -646,7 +646,7 @@ export class RulesService {
       undefined,
       { type: type, id: plexId },
       { plexId: plexId },
-    )) as unknown as AddCollectionMedia[];
+    )) as unknown as AddRemoveCollectionMedia[];
 
     try {
       for (const media of handleMedia) {
@@ -976,7 +976,6 @@ export class RulesService {
       const result = await ruleComparator.executeRulesWithData(
         group as RulesDto,
         [mediaResp as unknown as PlexLibraryItem],
-        true,
       );
 
       if (result) {

--- a/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -1,4 +1,5 @@
 import {
+  IComparisonStatistics,
   MaintainerrEvent,
   RuleHandlerFinishedEventDto,
   RuleHandlerProgressedEventDto,
@@ -12,7 +13,7 @@ import { PlexLibraryItem } from '../../api/plex-api/interfaces/library.interface
 import { PlexApiService } from '../../api/plex-api/plex-api.service';
 import { CollectionsService } from '../../collections/collections.service';
 import { Collection } from '../../collections/entities/collection.entities';
-import { AddCollectionMedia } from '../../collections/interfaces/collection-media.interface';
+import { AddRemoveCollectionMedia } from '../../collections/interfaces/collection-media.interface';
 import { SettingsService } from '../../settings/settings.service';
 import { TaskBase } from '../../tasks/task.base';
 import { TasksService } from '../../tasks/tasks.service';
@@ -41,6 +42,9 @@ export class RuleExecutorService extends TaskBase {
   plexDataType: EPlexDataType;
   workerData: PlexLibraryItem[];
   resultData: PlexLibraryItem[];
+  statisticsData: IComparisonStatistics[];
+  Data: PlexLibraryItem[];
+
   startTime: Date;
 
   constructor(
@@ -136,6 +140,7 @@ export class RuleExecutorService extends TaskBase {
               // prepare
               this.workerData = [];
               this.resultData = [];
+              this.statisticsData = [];
               this.plexData = { page: 0, finished: false, data: [] };
 
               this.plexDataType = rulegroup.dataType
@@ -145,10 +150,10 @@ export class RuleExecutorService extends TaskBase {
               // Run rules data chunks of 50
               while (!this.plexData.finished) {
                 await this.getPlexData(rulegroup.libraryId);
+
                 const ruleResult = await comparator.executeRulesWithData(
                   rulegroup,
                   this.plexData.data,
-                  false,
                   () => {
                     progressedEvent.processedEvaluations +=
                       this.plexData.data.length;
@@ -159,12 +164,15 @@ export class RuleExecutorService extends TaskBase {
                 );
 
                 if (ruleResult) {
-                  this.resultData.push(...ruleResult?.data);
+                  this.statisticsData.push(...ruleResult.stats);
+                  this.resultData.push(...ruleResult.data);
                 }
               }
+
               await this.handleCollection(
                 await this.rulesService.getRuleGroupById(rulegroup.id), // refetch to get latest changes
               );
+
               this.logger.log(
                 `Execution of rules for '${rulegroup.name}' done.`,
               );
@@ -222,7 +230,14 @@ export class RuleExecutorService extends TaskBase {
               ) {
                 await this.collectionService.addToCollection(
                   collection.id,
-                  [{ plexId: +child.ratingKey }] as AddCollectionMedia[],
+                  [
+                    {
+                      plexId: +child.ratingKey,
+                      reason: {
+                        type: 'media_added_manually',
+                      },
+                    },
+                  ],
                   true,
                 );
               }
@@ -239,7 +254,14 @@ export class RuleExecutorService extends TaskBase {
               ) {
                 await this.collectionService.removeFromCollection(
                   collection.id,
-                  [{ plexId: +media.plexId }] as AddCollectionMedia[],
+                  [
+                    {
+                      plexId: +media.plexId,
+                      reason: {
+                        type: 'media_removed_manually',
+                      },
+                    },
+                  ] satisfies AddRemoveCollectionMedia[],
                 );
               }
             }
@@ -310,21 +332,38 @@ export class RuleExecutorService extends TaskBase {
           ? currentCollectionData
           : [];
 
-        const dataToAdd = this.deDupe(
-          data
-            .filter((el) => !currentCollectionData.includes(el))
-            .map((el) => {
-              return { plexId: +el };
-            }),
+        const mediaToAdd = data.filter(
+          (el) => !currentCollectionData.includes(el),
         );
 
-        const dataToRemove = this.deDupe(
-          currentCollectionData
-            .filter((el) => !data.includes(el))
-            .map((el) => {
-              return { plexId: +el };
-            }),
+        const dataToAdd: AddRemoveCollectionMedia[] = this.prepareDataAmendment(
+          mediaToAdd.map((el) => {
+            return {
+              plexId: +el,
+              reason: {
+                type: 'media_added_by_rule',
+                data: this.statisticsData.find((stat) => el == stat.plexId),
+              },
+            } satisfies AddRemoveCollectionMedia;
+          }),
         );
+
+        const mediaToRemove = currentCollectionData.filter(
+          (el) => !data.includes(el),
+        );
+
+        const dataToRemove: AddRemoveCollectionMedia[] =
+          this.prepareDataAmendment(
+            mediaToRemove.map((el) => {
+              return {
+                plexId: +el,
+                reason: {
+                  type: 'media_removed_by_rule',
+                  data: this.statisticsData.find((stat) => el == stat.plexId),
+                },
+              } satisfies AddRemoveCollectionMedia;
+            }),
+          );
 
         if (dataToRemove.length > 0) {
           this.logInfo(
@@ -375,12 +414,14 @@ export class RuleExecutorService extends TaskBase {
     return await this.rulesService.getRuleGroups(true);
   }
 
-  private deDupe(arr: { plexId: number }[]): { plexId: number }[] {
-    const uniqueArr = [];
+  private prepareDataAmendment(
+    arr: AddRemoveCollectionMedia[],
+  ): AddRemoveCollectionMedia[] {
+    const uniqueArr: AddRemoveCollectionMedia[] = [];
     arr.filter(
       (item) =>
         !uniqueArr.find((el) => el.plexId === item.plexId) &&
-        uniqueArr.push({ plexId: item.plexId }),
+        uniqueArr.push(item),
     );
     return uniqueArr;
   }

--- a/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
+++ b/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
@@ -1,33 +1,37 @@
-import { useEffect, useRef, useState } from 'react'
-import { ICollection } from '../..'
-import LoadingSpinner, {
-  SmallLoadingSpinner,
-} from '../../../Common/LoadingSpinner'
-import Table from '../../../Common/Table'
-import GetApiHandler from '../../../../utils/ApiHandler'
-import useDebouncedState from '../../../..//hooks/useDebouncedState'
 import {
   FilterIcon,
   SearchIcon,
   SortAscendingIcon,
   SortDescendingIcon,
 } from '@heroicons/react/outline'
-import Badge from '../../../Common/Badge'
+import {
+  CollectionLogDto,
+  CollectionLogMetaMediaAddedByRule,
+  CollectionLogMetaMediaRemovedByRule,
+  isMetaActionedByRule,
+} from '@maintainerr/contracts'
+import { Editor } from '@monaco-editor/react'
 import _ from 'lodash'
+import { useEffect, useRef, useState } from 'react'
+import YAML from 'yaml'
+import { ICollection } from '../..'
+import useDebouncedState from '../../../..//hooks/useDebouncedState'
+import GetApiHandler from '../../../../utils/ApiHandler'
+import Alert from '../../../Common/Alert'
+import Badge from '../../../Common/Badge'
+import LoadingSpinner, {
+  SmallLoadingSpinner,
+} from '../../../Common/LoadingSpinner'
+import Modal from '../../../Common/Modal'
+import Table from '../../../Common/Table'
 
 interface ICollectionInfo {
   collection: ICollection
 }
 
-interface ICollectionInfoLog {
-  timestamp: Date
-  message: string
-  type: ECollectionLogType
-}
-
 interface ICollectionInfoLogApiResponse {
   totalSize: number
-  items: ICollectionInfoLog[]
+  items: CollectionLogDto[]
 }
 
 export enum ECollectionLogType {
@@ -37,12 +41,12 @@ export enum ECollectionLogType {
 }
 
 const CollectionInfo = (props: ICollectionInfo) => {
-  const [data, setData] = useState<ICollectionInfoLog[]>([])
+  const [data, setData] = useState<CollectionLogDto[]>([])
   const [page, setPage] = useState(0)
   const pageData = useRef<number>(0)
   const [totalSize, setTotalSize] = useState<number>(999)
   const totalSizeRef = useRef<number>(999)
-  const dataRef = useRef<ICollectionInfoLog[]>([])
+  const dataRef = useRef<CollectionLogDto[]>([])
   const loadingRef = useRef<boolean>(true)
   const loadingExtraRef = useRef<boolean>(false)
   const [searchFilter, debouncedSearchFilter, setSearchFilter] =
@@ -51,6 +55,8 @@ const CollectionInfo = (props: ICollectionInfo) => {
   const [currentFilter, setCurrentFilter] = useState<ECollectionLogType | -1>(
     -1,
   )
+  const [showMeta, setShowMeta] =
+    useState<Pick<LogMetaModalProps, 'meta' | 'title'>>()
 
   const fetchAmount = 25
 
@@ -107,7 +113,7 @@ const CollectionInfo = (props: ICollectionInfo) => {
       loadingExtraRef.current = true
     }
 
-    const resp: ICollectionInfoLogApiResponse = await GetApiHandler(
+    const resp = await GetApiHandler<ICollectionInfoLogApiResponse>(
       `/collections/logs/${props.collection.id}/content/${pageData.current}?size=${fetchAmount}${
         debouncedSearchFilter ? `&search=${debouncedSearchFilter}` : ''
       }${currentSort ? `&sort=${currentSort}` : ''}${currentFilter !== -1 ? `&filter=${currentFilter}` : ''}`,
@@ -154,173 +160,199 @@ const CollectionInfo = (props: ICollectionInfo) => {
   }
 
   return (
-    <div className="w-full">
-      <ul className="collection-info">
-        <li key={`collection-info-added`}>
-          <span>Date Added</span>
-          <p className="collection-info-item">
-            {props.collection.addDate
-              ? new Date(props.collection.addDate).toLocaleDateString()
-              : '-'}
-          </p>
-        </li>
-        <li key={`collection-info-handled`}>
-          <span>Handled media items</span>
-          <p className="collection-info-item">
-            {props.collection.handledMediaAmount}
-          </p>
-        </li>
-        <li key={`collection-info-duration`}>
-          <span>Last duration</span>
-          <p className="collection-info-item">
-            {props.collection.lastDurationInSeconds
-              ? formatDuration(props.collection.lastDurationInSeconds)
-              : '-'}
-          </p>
-        </li>
-      </ul>
+    <>
+      <div className="w-full">
+        <ul className="collection-info">
+          <li key={`collection-info-added`}>
+            <span>Date Added</span>
+            <p className="collection-info-item">
+              {props.collection.addDate
+                ? new Date(props.collection.addDate).toLocaleDateString()
+                : '-'}
+            </p>
+          </li>
+          <li key={`collection-info-handled`}>
+            <span>Handled media items</span>
+            <p className="collection-info-item">
+              {props.collection.handledMediaAmount}
+            </p>
+          </li>
+          <li key={`collection-info-duration`}>
+            <span>Last duration</span>
+            <p className="collection-info-item">
+              {props.collection.lastDurationInSeconds
+                ? formatDuration(props.collection.lastDurationInSeconds)
+                : '-'}
+            </p>
+          </li>
+        </ul>
 
-      <div className="heading mt-5 font-bold text-zinc-300">
-        <h2>{'Logs'}</h2>
-      </div>
-
-      <div className="w-full pl-2 pr-2">
-        {/* full container */}
-        <div className="mb-2 flex flex-grow flex-col sm:flex-grow-0 sm:flex-row sm:justify-end">
-          {/* search */}
-          <div className="mr-2 mt-4 flex w-full flex-grow sm:w-1/2">
-            <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-zinc-800 px-3 text-sm text-gray-100">
-              <SearchIcon className="h-6 w-6" />
-            </span>
-            <input
-              type="text"
-              className="rounded-r-only"
-              value={searchFilter}
-              onChange={(e) => setSearchFilter(e.target.value as string)}
-            />
-          </div>
-
-          {/* sort/filter container */}
-          <div className="mb-2 flex flex-1 flex-row justify-between sm:mb-0 sm:flex-none">
-            {/* sort */}
-            <div className="mr-2 mt-4 flex flex-grow sm:w-1/2">
-              <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-zinc-800 px-3 text-sm text-gray-100">
-                {currentSort === 'DESC' ? (
-                  <SortDescendingIcon className="h-6 w-6" />
-                ) : (
-                  <SortAscendingIcon className="h-6 w-6" />
-                )}
-              </span>
-              <select
-                id="sort"
-                name="sort"
-                onChange={(e) => {
-                  setCurrentSort(e.target.value as 'ASC' | 'DESC')
-                }}
-                value={currentSort}
-                className="rounded-r-only"
-              >
-                <option value="DESC">{'Descending'}</option>
-                <option value="ASC">{'Ascending'}</option>
-              </select>
-            </div>
-
-            {/* filter */}
-            <div className="mt-4 flex flex-grow sm:w-1/2">
-              <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-zinc-800 px-3 text-sm text-gray-100">
-                <FilterIcon className="h-6 w-6" />
-              </span>
-              <select
-                id="filter"
-                name="filter"
-                onChange={(e) => {
-                  setCurrentFilter(+e.target.value as ECollectionLogType)
-                }}
-                value={currentFilter}
-                className="rounded-r-only"
-              >
-                <option key={`filter-option-all`} value={-1}>
-                  -
-                </option>
-                {Object.values(ECollectionLogType)
-                  .filter((value) => typeof value === 'number')
-                  .map((value, index) => {
-                    return (
-                      <option key={`filter-option-${index}`} value={+value}>
-                        {ECollectionLogType[+value].charAt(0).toUpperCase() +
-                          ECollectionLogType[+value].slice(1).toLowerCase()}
-                      </option>
-                    )
-                  })}
-              </select>
-            </div>
-          </div>
+        <div className="heading mt-5 font-bold text-zinc-300">
+          <h2>{'Logs'}</h2>
         </div>
 
-        {/* data */}
-        <Table>
-          <thead>
-            <tr>
-              <Table.TH>{'DATE'}</Table.TH>
-              <Table.TH>{'LABEL'}</Table.TH>
-              <Table.TH>{'EVENT'}</Table.TH>
-            </tr>
-          </thead>
-          <Table.TBody>
-            {loadingRef.current ? (
+        <div className="w-full pl-2 pr-2">
+          {/* full container */}
+          <div className="mb-2 flex flex-grow flex-col sm:flex-grow-0 sm:flex-row sm:justify-end">
+            {/* search */}
+            <div className="mr-2 mt-4 flex w-full flex-grow sm:w-1/2">
+              <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-zinc-800 px-3 text-sm text-gray-100">
+                <SearchIcon className="h-6 w-6" />
+              </span>
+              <input
+                type="text"
+                className="rounded-r-only"
+                value={searchFilter}
+                onChange={(e) => setSearchFilter(e.target.value as string)}
+              />
+            </div>
+
+            {/* sort/filter container */}
+            <div className="mb-2 flex flex-1 flex-row justify-between sm:mb-0 sm:flex-none">
+              {/* sort */}
+              <div className="mr-2 mt-4 flex flex-grow sm:w-1/2">
+                <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-zinc-800 px-3 text-sm text-gray-100">
+                  {currentSort === 'DESC' ? (
+                    <SortDescendingIcon className="h-6 w-6" />
+                  ) : (
+                    <SortAscendingIcon className="h-6 w-6" />
+                  )}
+                </span>
+                <select
+                  id="sort"
+                  name="sort"
+                  onChange={(e) => {
+                    setCurrentSort(e.target.value as 'ASC' | 'DESC')
+                  }}
+                  value={currentSort}
+                  className="rounded-r-only"
+                >
+                  <option value="DESC">{'Descending'}</option>
+                  <option value="ASC">{'Ascending'}</option>
+                </select>
+              </div>
+
+              {/* filter */}
+              <div className="mt-4 flex flex-grow sm:w-1/2">
+                <span className="inline-flex cursor-default items-center rounded-l-md border border-r-0 border-gray-500 bg-zinc-800 px-3 text-sm text-gray-100">
+                  <FilterIcon className="h-6 w-6" />
+                </span>
+                <select
+                  id="filter"
+                  name="filter"
+                  onChange={(e) => {
+                    setCurrentFilter(+e.target.value as ECollectionLogType)
+                  }}
+                  value={currentFilter}
+                  className="rounded-r-only"
+                >
+                  <option key={`filter-option-all`} value={-1}>
+                    -
+                  </option>
+                  {Object.values(ECollectionLogType)
+                    .filter((value) => typeof value === 'number')
+                    .map((value, index) => {
+                      return (
+                        <option key={`filter-option-${index}`} value={+value}>
+                          {ECollectionLogType[+value].charAt(0).toUpperCase() +
+                            ECollectionLogType[+value].slice(1).toLowerCase()}
+                        </option>
+                      )
+                    })}
+                </select>
+              </div>
+            </div>
+          </div>
+
+          {/* data */}
+          <Table>
+            <thead>
               <tr>
-                <Table.TD colSpan={3} noPadding>
-                  <LoadingSpinner />
-                </Table.TD>
+                <Table.TH>{'DATE'}</Table.TH>
+                <Table.TH>{'LABEL'}</Table.TH>
+                <Table.TH>{'EVENT'}</Table.TH>
               </tr>
-            ) : (
-              <>
-                {data.map((row: ICollectionInfoLog, index: number) => {
-                  return (
-                    <tr key={`log-list-${index}`}>
-                      {/* timestamp */}
-                      <Table.TD className="text-gray-300">
-                        {new Date(row.timestamp).toLocaleString()}
-                      </Table.TD>
+            </thead>
+            <Table.TBody>
+              {loadingRef.current ? (
+                <tr>
+                  <Table.TD colSpan={3} noPadding>
+                    <LoadingSpinner />
+                  </Table.TD>
+                </tr>
+              ) : (
+                <>
+                  {data.map((row: CollectionLogDto, index: number) => {
+                    return (
+                      <tr key={`log-list-${index}`}>
+                        {/* timestamp */}
+                        <Table.TD className="text-gray-300">
+                          {new Date(row.timestamp).toLocaleString()}
+                        </Table.TD>
 
-                      {/* label */}
-                      <Table.TD className="text-gray-300">
-                        <Badge
-                          badgeType={
-                            row.type === ECollectionLogType.COLLECTION
-                              ? 'danger'
-                              : row.type === ECollectionLogType.MEDIA
-                                ? 'warning'
-                                : row.type === ECollectionLogType.RULES
-                                  ? 'success'
-                                  : 'default'
-                          }
-                        >
-                          {ECollectionLogType[row.type].toUpperCase()}
-                        </Badge>
-                      </Table.TD>
+                        {/* label */}
+                        <Table.TD className="text-gray-300">
+                          <Badge
+                            badgeType={
+                              row.type === ECollectionLogType.COLLECTION
+                                ? 'danger'
+                                : row.type === ECollectionLogType.MEDIA
+                                  ? 'warning'
+                                  : row.type === ECollectionLogType.RULES
+                                    ? 'success'
+                                    : 'default'
+                            }
+                          >
+                            {ECollectionLogType[row.type].toUpperCase()}
+                          </Badge>
+                        </Table.TD>
 
-                      {/* message */}
-                      <Table.TD className="text-gray-300">
-                        {row.message}
+                        {/* message */}
+                        <Table.TD className="text-gray-300">
+                          {row.message}
+                          {row.meta &&
+                            row.type == ECollectionLogType.MEDIA &&
+                            isMetaActionedByRule(row.meta) && (
+                              <>
+                                {' '}
+                                <button
+                                  type="button"
+                                  className="text-gray-400 hover:text-gray-300"
+                                  onClick={() => {
+                                    if (!isMetaActionedByRule(row.meta)) return
+
+                                    setShowMeta({
+                                      meta: row.meta,
+                                      title: row.message,
+                                    })
+                                  }}
+                                >
+                                  (meta)
+                                </button>
+                              </>
+                            )}
+                        </Table.TD>
+                      </tr>
+                    )
+                  })}
+
+                  {loadingExtraRef.current ? (
+                    <tr>
+                      <Table.TD colSpan={2} noPadding>
+                        <SmallLoadingSpinner className="m-auto mb-2 mt-2 w-8" />
                       </Table.TD>
                     </tr>
-                  )
-                })}
-
-                {loadingExtraRef.current ? (
-                  <tr>
-                    <Table.TD colSpan={2} noPadding>
-                      <SmallLoadingSpinner className="m-auto mb-2 mt-2 w-8" />
-                    </Table.TD>
-                  </tr>
-                ) : undefined}
-              </>
-            )}
-          </Table.TBody>
-        </Table>
+                  ) : undefined}
+                </>
+              )}
+            </Table.TBody>
+          </Table>
+        </div>
       </div>
-    </div>
+      {showMeta ? (
+        <LogMetaModal onClose={() => setShowMeta(undefined)} {...showMeta} />
+      ) : undefined}
+    </>
   )
 }
 
@@ -349,3 +381,52 @@ const formatDuration = (seconds: number) => {
 }
 
 export default CollectionInfo
+
+interface LogMetaModalProps {
+  onClose: () => void
+  title: string
+  meta: CollectionLogMetaMediaAddedByRule | CollectionLogMetaMediaRemovedByRule
+}
+
+const LogMetaModal = (props: LogMetaModalProps) => {
+  const editorRef = useRef(undefined)
+
+  function handleEditorDidMount(editor: any, monaco: any) {
+    editorRef.current = editor
+  }
+
+  return (
+    <div className={'h-full w-full'}>
+      <Modal
+        loading={false}
+        backgroundClickable={false}
+        onOk={props.onClose}
+        okText={'Close'}
+        okButtonType={'primary'}
+        title={'Metadata'}
+      >
+        <div className="h-[80vh] overflow-hidden">
+          <div className="mt-1">
+            <Alert type="info">
+              Below are the rule evaluation results that triggered this action.
+              The output follows the same format as Test Media. Refer to the
+              documentation for guidance on interpreting this output.
+            </Alert>
+          </div>
+          <label htmlFor={`editor-field`} className="text-label mb-3">
+            Output
+          </label>
+          <div className="editor-container h-full">
+            <Editor
+              options={{ readOnly: true, minimap: { enabled: false } }}
+              defaultLanguage="yaml"
+              theme="vs-dark"
+              value={YAML.stringify(props.meta.data)}
+              onMount={handleEditorDidMount}
+            />
+          </div>
+        </div>
+      </Modal>
+    </div>
+  )
+}


### PR DESCRIPTION
### Description

This PR introduces a meta column to collection logs for storing arbitrary, but typesafe, data. Here I am saving the rule evaluation results against the added & removed media collection log. These can then be viewed by clicking the meta link next to the log message.

### Related issue

This should help in debugging #1446 - and users often wonder why something got added or removed so this should help those guys out too.

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code.
- [x] I have linted and formatted my code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

### How to test

Please describe the steps to test your changes, including any setup required.

1. Create a collection with some rules that will match some media
2. Run rules
3. Collection -> Info
4. A meta link should appear next to the log message. Clicking that should bring up a modal similar to test media with the rule results displayed.
