### PR TITLE
chore(ci): Fix Docker image tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,6 @@ jobs:
             ${{ env.GHCR_SLUG }}
           tags: |
             type=raw,value=main
-            type=raw,value=develop
           labels: org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Create manifest list and push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,8 +130,8 @@ jobs:
             ${{ env.DOCKERHUB_SLUG }}
             ${{ env.GHCR_SLUG }}
           tags: |
-            ${{ env.GHCR_SLUG }}:main
-            ${{ env.DOCKERHUB_SLUG }}:develop
+            type=raw,value=main
+            type=raw,value=develop
           labels: org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Create manifest list and push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,10 +181,10 @@ jobs:
             ${{ env.DOCKERHUB_SLUG }}
             ${{ env.GHCR_SLUG }}
           tags: |
-            ${{ env.GHCR_SLUG }}:${{ steps.package-version.outputs.current-version}}
-            ${{ env.GHCR_SLUG }}:latest
-            ${{ env.DOCKERHUB_SLUG }}:${{ steps.package-version.outputs.current-version}}
-            ${{ env.DOCKERHUB_SLUG }}:latest
+            type=raw,value=latest
+            type=semver,pattern={{version}},value=${{ steps.package-version.outputs.current-version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.package-version.outputs.current-version }}
+            type=semver,pattern={{major}},value=${{ steps.package-version.outputs.current-version }}
           labels: org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Create manifest list and push


### PR DESCRIPTION
### Description

I poo poo'd the Docker image tags and a bunch of badly named ones got pushed (see https://hub.docker.com/r/jorenn92/maintainerr/tags - can we delete these?). I created a temporary branch to re-run just the Docker image build for 2.14.0 after I fixed the workflow.

I've added major and major.minor tags here as well. I like to pin to a major version as upgrading might involve manual steps. I think using `:latest` is a bad idea in most cases.

