### PR TITLE
fix: Test media targeting the wrong rule group

### DIFF
--- a/ui/src/components/Collection/CollectionDetail/index.tsx
+++ b/ui/src/components/Collection/CollectionDetail/index.tsx
@@ -219,8 +219,6 @@ const CollectionDetail: React.FC<ICollectionDetail> = (
       {mediaTestModalOpen && props.collection?.id ? (
         <TestMediaItem
           collectionId={+props.collection.id}
-          libraryId={props.libraryId}
-          dataType={props.collection.type}
           onCancel={() => {
             setMediaTestModalOpen(false)
           }}


### PR DESCRIPTION
### Description

I incorrectly refactored to use the collection ID instead of the rule group ID, they are typically aligned but not always. This reverts that specific change.

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code.
- [x] I have linted and formatted my code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

### How to test

Please describe the steps to test your changes, including any setup required.

1. Use Test Media and validate the result