### PR TITLE
fix: Test media failing due to missing AbortSignal

### DIFF
--- a/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -49,7 +49,7 @@ export class RuleComparatorService {
   plexDataType: EPlexDataType;
   statistics: IComparisonStatistics[];
   statisticWorker: IRuleComparisonResult[];
-  abortSignal: AbortSignal;
+  abortSignal?: AbortSignal;
 
   constructor(
     private readonly valueGetter: ValueGetterService,
@@ -192,10 +192,10 @@ export class RuleComparatorService {
         ruleGroup,
         this.plexDataType,
       );
-      this.abortSignal.throwIfAborted();
+      this.abortSignal?.throwIfAborted();
 
       secondVal = await this.getSecondValue(rule, data[i], ruleGroup, firstVal);
-      this.abortSignal.throwIfAborted();
+      this.abortSignal?.throwIfAborted();
 
       if (
         (firstVal !== undefined || null) &&


### PR DESCRIPTION
### Description

Test media doesn't pass an abort signal (by design) so we just need to check if it's available before using. Another bug that would've been caught with strict null checks.

### How to test

1. Validate test media now works