### PR TITLE
fix: Tautulli settings not updating until restart

### DIFF
--- a/server/src/modules/settings/settings.service.ts
+++ b/server/src/modules/settings/settings.service.ts
@@ -274,6 +274,10 @@ export class SettingsService implements SettingDto {
         tautulli_api_key: null,
       });
 
+      this.tautulli_url = null;
+      this.tautulli_api_key = null;
+      this.tautulli.init();
+
       return { status: 'OK', code: 1, message: 'Success' };
     } catch (e) {
       this.logger.error('Error removing Tautulli settings: ', e);
@@ -292,6 +296,10 @@ export class SettingsService implements SettingDto {
         tautulli_url: settings.url,
         tautulli_api_key: settings.api_key,
       });
+
+      this.tautulli_url = settings.url;
+      this.tautulli_api_key = settings.api_key;
+      this.tautulli.init();
 
       return { status: 'OK', code: 1, message: 'Success' };
     } catch (e) {


### PR DESCRIPTION
### Description

When updating Tautulli settings, the in-memory values were not being updated and the API client was not re-built. This meant that any calls (excluding the Test endpoint) to the Tautulli API would use the old settings, which could be empty on a fresh install.

### How to test

1. Empty your Tautulli settings out
2. Restart the app
3. Add Tautulli settings
4. Add a Tautulli rule group
5. Run rules and check that everything worked ok