### PR TITLE
fix: Incorrect sectionResults operator

### DIFF
--- a/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -322,14 +322,13 @@ export class RuleComparatorService {
     result: boolean,
   ) {
     const index = this.statistics.findIndex((el) => +el.plexId === +plexId);
-    const sectionIndex = this.statistics[index].sectionResults.length - 1;
+    const lastSectionIndex = this.statistics[index].sectionResults.length - 1;
 
     // push result to currently last section
-    this.statistics[index].sectionResults[sectionIndex].ruleResults.push({
-      operator:
-        rule.operator === null || rule.operator === undefined
-          ? RuleOperators[1]
-          : RuleOperators[rule.operator],
+    this.statistics[index].sectionResults[lastSectionIndex].ruleResults.push({
+      ...(rule.operator != null
+        ? { operator: RuleOperators[rule.operator] }
+        : undefined),
       action: RulePossibility[rule.action].toLowerCase(),
       firstValueName: this.ruleConstanstService.getValueHumanName(
         rule.firstVal,
@@ -342,18 +341,6 @@ export class RuleComparatorService {
       secondValue: secondVal,
       result: result,
     });
-
-    // If it's the first rule of a section and not the first section, add the operator to the sectionResult
-    if (
-      sectionIndex > 0 &&
-      this.statistics[index].sectionResults[sectionIndex].ruleResults.length ===
-        1
-    ) {
-      this.statistics[index].sectionResults[sectionIndex].operator =
-        rule.operator === null || rule.operator === undefined
-          ? RuleOperators[1]
-          : RuleOperators[rule.operator];
-    }
   }
 
   private handleSectionAction(sectionActionAnd: boolean) {


### PR DESCRIPTION
### Description

I feel like I'm playing whac-a-mole with statistics bugs.

A rule that looked like this: `AND(2 rules), OR(1 rule), AND(1 rule)` would result in the section 3 (id: 2) operator being `OR` instead of `AND` in metadata / test media **(the actual logic is fine)**. I've removed the block that was causing the issue, there's other code that already handles setting the operator correctly.

I have also removed the operator from the first rule in the ruleResults as it has no effect on the end result, we're leaking an implementation detail there really.

Was introduced in #1777 when I was fixing a different bug.

### How to test

1. Create a rule group that looks like the example above
2. Run rules
3. Validate the first couple of additions metadata is correct

