### PR TITLE
fix: prepend missing basePath occurences

### DIFF
--- a/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -1,6 +1,6 @@
-import React, { memo, useEffect, useState, useMemo } from 'react'
-import GetApiHandler from '../../../../utils/ApiHandler'
 import Image from 'next/image'
+import React, { memo, useEffect, useMemo, useState } from 'react'
+import GetApiHandler from '../../../../utils/ApiHandler'
 
 interface ModalContentProps {
   onClose: () => void
@@ -32,16 +32,17 @@ interface Metadata {
   Guid: { id: string }[]
 }
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH
 const iconMap: Record<string, Record<string, string>> = {
   imdb: {
-    audience: '/icons_logos/imdb_icon.svg',
+    audience: `${basePath}/icons_logos/imdb_icon.svg`,
   },
   rottentomatoes: {
-    critic: '/icons_logos/rt_critic.svg',
-    audience: 'icons_logos/rt_audience.svg',
+    critic: `${basePath}/icons_logos/rt_critic.svg`,
+    audience: `${basePath}/icons_logos/rt_audience.svg`,
   },
   themoviedb: {
-    audience: '/icons_logos/tmdb_icon.svg',
+    audience: `${basePath}/icons_logos/tmdb_icon.svg`,
   },
 }
 
@@ -60,6 +61,8 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
         ['show', 'season', 'episode'].includes(mediaType) ? 'tv' : mediaType,
       [mediaType],
     )
+
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH
 
     useEffect(() => {
       GetApiHandler('/plex').then((resp) =>
@@ -191,7 +194,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
                         target="_blank"
                       >
                         <Image
-                          src={`/icons_logos/tmdb_logo.svg`}
+                          src={`${basePath}/icons_logos/tmdb_logo.svg`}
                           alt="TMDB Logo"
                           width={128}
                           height={32}
@@ -206,7 +209,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
                       target="_blank"
                     >
                       <Image
-                        src={`/icons_logos/plex_logo.svg`}
+                        src={`${basePath}/icons_logos/plex_logo.svg`}
                         alt="Plex Logo"
                         width={128}
                         height={32}
@@ -221,7 +224,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
                         target="_blank"
                       >
                         <Image
-                          src={`/icons_logos/tautulli_logo.svg`}
+                          src={`${basePath}/icons_logos/tautulli_logo.svg`}
                           alt="Plex Logo"
                           width={128}
                           height={32}

--- a/ui/src/components/Settings/Logs/index.tsx
+++ b/ui/src/components/Settings/Logs/index.tsx
@@ -133,7 +133,8 @@ const Logs = () => {
   const logsRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    const es = new ReconnectingEventSource('/api/logs/stream')
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+    const es = new ReconnectingEventSource(`${basePath}/api/logs/stream`)
     es.addEventListener('log', (event) => {
       const message: LogEvent = JSON.parse(event.data)
       setLogLines((prev) => [...prev, message])

--- a/ui/src/contexts/events-context.tsx
+++ b/ui/src/contexts/events-context.tsx
@@ -8,7 +8,8 @@ export const EventsProvider = (props: any) => {
   const [eventSource, setEventSource] = useState<EventSource>()
 
   useEffect(() => {
-    const es = new ReconnectingEventSource('/api/events/stream')
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+    const es = new ReconnectingEventSource(`${basePath}/api/events/stream`)
 
     es.onerror = (e) => {
       console.error('EventSource failed:', e)


### PR DESCRIPTION
### Description

This PR addresses inconsistencies in how `basePath` is handled across the Maintainerr frontend.

Following the discussion in [#1562](https://github.com/jorenn92/Maintainerr/pull/1562#issuecomment-2917398495), I identified several places where the `basePath` was not respected, causing issues when the app is hosted under a subpath (e.g., `/maintainerr`):

* Some static assets in the Media modal (e.g., rating icons) were using absolute paths (`/`) without prepending the `basePath`.
* Both `ReconnectingEventSource` instances (for `/api/events/stream` and `/api/logs/stream`) were also using hardcoded paths, resulting in repeated 404 errors in the browser console when running Maintainerr under a custom `BASE_PATH`.

These issues are now resolved by ensuring all asset and API paths correctly prepend `process.env.NEXT_PUBLIC_BASE_PATH`.

---

### Related Issue

No issue has been opened for this yet.

---

### Checklist

* [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
* [x] I have performed a self-review of my code.
* [x] I have linted and formatted my code.
* [x] My changes generate no new warnings.
* [x] New and existing unit tests pass locally with my changes.

---

### How to Test

1. Build and run the app.
2. Set the `BASE_PATH` environment variable (e.g., `BASE_PATH=/maintainerr`).

3. Navigate through the interface (especially the Media modal and Settings panel on the Logs tab).

All assets should load correctly.
Event streams (`/api/events/stream`, `/api/logs/stream`) should function without triggering 404 errors.
No errors or warnings should appear in the browser console related to missing assets or API calls.

---

### Additional Context

N/A
