### PR TITLE
fix: Prevent undefined base path appearing in path

### DIFF
--- a/ui/src/components/Common/MediaCard/MediaModal/index.tsx
+++ b/ui/src/components/Common/MediaCard/MediaModal/index.tsx
@@ -32,7 +32,7 @@ interface Metadata {
   Guid: { id: string }[]
 }
 
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
 const iconMap: Record<string, Record<string, string>> = {
   imdb: {
     audience: `${basePath}/icons_logos/imdb_icon.svg`,
@@ -62,7 +62,7 @@ const MediaModalContent: React.FC<ModalContentProps> = memo(
       [mediaType],
     )
 
-    const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
 
     useEffect(() => {
       GetApiHandler('/plex').then((resp) =>

--- a/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -131,8 +131,6 @@ const AddModal = (props: AddModal) => {
       (x) => x.id == Application.OVERSEERR,
     ) ?? false
 
-  const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
-
   function updateLibraryId(value: string) {
     const lib = LibrariesCtx.libraries.find(
       (el: ILibrary) => +el.key === +value,

--- a/ui/src/components/Settings/Logs/index.tsx
+++ b/ui/src/components/Settings/Logs/index.tsx
@@ -133,7 +133,7 @@ const Logs = () => {
   const logsRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
     const es = new ReconnectingEventSource(`${basePath}/api/logs/stream`)
     es.addEventListener('log', (event) => {
       const message: LogEvent = JSON.parse(event.data)

--- a/ui/src/contexts/events-context.tsx
+++ b/ui/src/contexts/events-context.tsx
@@ -8,7 +8,7 @@ export const EventsProvider = (props: any) => {
   const [eventSource, setEventSource] = useState<EventSource>()
 
   useEffect(() => {
-    const basePath = process.env.NEXT_PUBLIC_BASE_PATH
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
     const es = new ReconnectingEventSource(`${basePath}/api/events/stream`)
 
     es.onerror = (e) => {


### PR DESCRIPTION
### Description

undefined gets output in template literals. In the `release-workflow` branch NEXT_PUBLIC_BASE_PATH is always defined which is where this change originated from.

### How to test

1. The stream endpoints should now work + the logos
