### PR TITLE
🐛 Fix boolean comparator bug

### DIFF
--- a/server/src/modules/rules/helpers/rule.comparator.service.ts
+++ b/server/src/modules/rules/helpers/rule.comparator.service.ts
@@ -198,8 +198,8 @@ export class RuleComparatorService {
       this.abortSignal?.throwIfAborted();
 
       if (
-        (firstVal !== undefined || null) &&
-        (secondVal !== undefined || null)
+        (firstVal !== undefined || firstVal !==  null) &&
+        (secondVal !== undefined || secondVal !== null)
       ) {
         // do action
         const comparisonResult = this.doRuleAction(


### PR DESCRIPTION
This might be what was causing [https://features.maintainerr.info/posts/54/add-comparison-with-null-values](null values still causing matches).

### Description

Boolean logic issue where `|| null` is not parsed as "is not undefined or null" but "is not undefined" as `|| null` always evaluates to "or is false" which is always false.

### Related issue

Potentially fixes issues like #1406.

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code.
- [x] I have linted and formatted my code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

