### PR TITLE
fix: Collection Plex ID not being reset in rare circumstances

### DIFF
--- a/server/src/modules/collections/collections.service.ts
+++ b/server/src/modules/collections/collections.service.ts
@@ -654,7 +654,7 @@ export class CollectionsService {
           );
 
           if (resp.code === 1) {
-            await this.collectionRepo.save({
+            collection = await this.collectionRepo.save({
               ...collection,
               plexId: null,
             });


### PR DESCRIPTION
The Plex ID wasn't being set to null on the returned collection object. This object ends up being re-persisted via a call to AddCollectionRunDuration, which has a side effect of saving the whole object, not just the run duration...