### PR TITLE
fix(notifications): alignment and text consistency

### DIFF
--- a/server/src/modules/notifications/notifications.service.ts
+++ b/server/src/modules/notifications/notifications.service.ts
@@ -688,7 +688,7 @@ export class NotificationService {
         case NotificationType.MEDIA_ABOUT_TO_BE_HANDLED:
           subject = 'Media About to be Handled';
           message =
-            "⏰ Reminder: {media_title} will be handled in {days} days. If you want to keep it, make sure to take action before it's gone. Don’t miss out!";
+            "⏰ Reminder: '{media_title}' will be handled in {days} days. If you want to keep it, make sure to take action before it's gone. Don’t miss out!";
           break;
         case NotificationType.MEDIA_ADDED_TO_COLLECTION:
           subject = 'Media Added to Collection';
@@ -784,7 +784,7 @@ export class NotificationService {
 
           const result = titles
             .map((name) => `* ${name.charAt(0).toUpperCase() + name.slice(1)}`)
-            .join(' \n');
+            .join(' \n ');
 
           message = message.replace('{media_items}', result);
         } else {


### PR DESCRIPTION
### Description

On some platforms, the notifications for multi-items are misaligned due to a preceding space character:

<img width="590" height="485" alt="image" src="https://github.com/user-attachments/assets/e038acd8-5784-4f4e-b1ab-8f88762f868e" />

Single media item reminders also don't have the title wrapped in single quotes:

<img width="600" height="181" alt="image" src="https://github.com/user-attachments/assets/6e7f969e-de04-4c27-acc9-c2f31cebb874" />

Which is inconsistent with other notifications and sometimes makes picking out the title harder:

<img width="597" height="165" alt="image" src="https://github.com/user-attachments/assets/e293c5bb-3457-40f5-9970-4c1fd4416941" />

### Related issue

N/A

### Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [x] I have performed a self-review of my code.
- [x] I have linted and formatted my code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.

### How to test

N/A, text change only.

### Additional context

N/A
