### PR TITLE
chore(ci): Fix for code scanning alert no. 9: Untrusted Checkout TOCTOU

### DIFF
--- a/.github/workflows/release_pr.yml
+++ b/.github/workflows/release_pr.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
+          ref: ${{ github.event.issue.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Potential fix for [https://github.com/Maintainerr/Maintainerr/security/code-scanning/9](https://github.com/Maintainerr/Maintainerr/security/code-scanning/9)

The issue arises from using `${{ github.event.issue.number }}` to assemble a mutable ref (`refs/pull/.../head`) when checking out code in a privileged context. The best fix is to change the checkout step so it checks out the code using the immutable SHA of the pull request head commit. In the context of an `issue_comment` or `pull_request_target` workflow, you should use `${{ github.event.issue.pull_request.head.sha }}` for the `ref` input. This ensures that the workflow runs using the specific commit that triggered the workflow, not a potentially mutated branch.

What to change:
- In `.github/workflows/release_pr.yml` at lines 44–47, update the `ref` in the checkout step from the mutable pull request ref to the immutable SHA.
- No extra imports or steps are needed; just change the `ref:` line appropriately.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
