### PR TITLE
feat: Add Sonarr "Episodes - Missing count" rule field

### DIFF
--- a/apps/server/src/modules/rules/constants/rules.constants.ts
+++ b/apps/server/src/modules/rules/constants/rules.constants.ts
@@ -861,6 +861,18 @@ export class RuleConstants {
           mediaType: MediaType.SHOW,
           type: RuleType.TEXT,
         },
+        {
+          id: 28,
+          name: 'missing_episodes',
+          humanName: 'Episodes - Missing count',
+          mediaType: MediaType.SHOW,
+          type: RuleType.NUMBER,
+          showType: [
+            EPlexDataType.SHOWS,
+            EPlexDataType.SEASONS,
+            EPlexDataType.EPISODES,
+          ],
+        },
       ],
     },
     {

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -379,6 +379,17 @@ export class SonarrGetterService {
         case 'seriesType': {
           return showResponse.seriesType ?? null;
         }
+        case 'missing_episodes': {
+          if ([EPlexDataType.SEASONS, EPlexDataType.EPISODES].includes(dataType)) {
+            return season?.statistics
+              ? season.statistics.episodeCount - season.statistics.episodeFileCount
+              : null;
+          }
+
+          return showResponse.statistics
+            ? showResponse.statistics.episodeCount - showResponse.statistics.episodeFileCount
+            : null;
+        }
       }
     } catch (e) {
       this.logger.warn(


### PR DESCRIPTION
## Description

This pull request adds a new Sonarr rule field to Maintainerr that allows users to create rules based on the number of missing episodes in TV series.

## Changes

### 1. Added New Rule Field Definition
**File:** `apps/server/src/modules/rules/constants/rules.constants.ts`

Added new property object with ID 28 to the Sonarr application:
- **Name:** `missing_episodes`
- **Display Name:** `Episodes - Missing count`
- **Type:** NUMBER
- **Applicable to:** Shows, Seasons, and Episodes

### 2. Implemented Missing Episodes Calculation Logic
**File:** `apps/server/src/modules/rules/getter/sonarr-getter.service.ts`

Added new case handler that:
- Calculates missing episodes: `episodeCount - episodeFileCount`
- Supports different media types:
  - **Shows:** Total missing episodes across all seasons
  - **Seasons:** Missing episodes for that specific season
  - **Episodes:** Missing episodes for the season

## How It Works

1. User selects "Sonarr - Episodes - Missing count" as First Value in rules
2. User chooses a NUMBER operator (Bigger, Equals, Smaller, etc.)
3. User sets a comparison value (e.g., 0, 5, 10)
4. The rule filters series based on missing episode count

## Use Cases

- **Find Incomplete Series:** `Sonarr - Episodes - Missing count Bigger 0`
- **Protect Complete Series:** In exclusions: `Sonarr - Episodes - Missing count Equals 0`
- **Find Heavily Incomplete Series:** `Sonarr - Episodes - Missing count Bigger 5`
- **Combine with Other Rules:** Mix with Plex and Tautulli rules for complex filtering

## Technical Details

- Uses existing Sonarr API: `statistics.episodeCount` and `statistics.episodeFileCount`
- No additional API calls or database changes required
- Fully compatible with existing rule system
- No breaking changes
- Works with Shows, Seasons, and Episodes media types

## Testing Status

✅ Code compiled successfully
✅ Integrated with rule system
✅ Compatible with all media types
✅ Ready for production