### PR TITLE
fix: resolve interactive prompt during devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,7 +41,8 @@ USER ${USERNAME}
 
 # Install global tools that might be useful for development
 # Turbo is already installed as a dev dependency, but global install can be helpful
-RUN yarn global add turbo@^2
+# Use --yes to avoid interactive prompts during container build
+RUN yes | yarn global add turbo@^2 || yarn global add turbo@^2
 
 # Set environment variables for development
 ENV NODE_ENV=development


### PR DESCRIPTION
Fixes the dev container setup hanging on an interactive prompt when Corepack tries to download yarn. The 'yarn global add turbo' command now uses 'yes |' to automatically answer confirmation prompts during container build, ensuring fully automated setup in GitHub Codespaces.

@ydkmlt84 See Discord