### PR TITLE
build: maintain support for legacy Docker repo until external organiz…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map(select(startswith("${{ env.DOCKERHUB_LEGACY_SLUG }}")) | "--tag " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.DOCKERHUB_LEGACY_SLUG }}@sha256:%s ' *)
+            $(printf '${{ env.DOCKERHUB_SLUG }}@sha256:%s ' *)
 
   after-effects:
     name: Actions taken after a release.


### PR DESCRIPTION
This is an attempt to re-push to jorenn92/maintainerr. 

Unraid Community apps and Synology users are not able to update anymore since the switch to maintainerr/maintainerr. 
For the foreseeable future, we need to keep pushing releases to the jorenn92 repo. 

I did **NOT** test a release build. Please keep this in mind.