### PR TITLE
fix: prevent rule-removed items from being re-added as manual additions

### DIFF
--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -201,6 +201,35 @@ describe('RuleExecutorService', () => {
     );
   });
 
+  it('does not re-add a rule-removed item as manual when media server returns stale children', async () => {
+    const { service, mediaServer, collectionService } = createService(
+      MediaServerType.PLEX,
+    );
+
+    // Media server still returns the item as a child (stale / sync delay)
+    mediaServer.getCollectionChildren.mockResolvedValue([{ id: 'm-stale' }]);
+    // DB no longer has the item (rule already removed it)
+    collectionService.getCollectionMedia.mockResolvedValue([]);
+
+    await (
+      service as unknown as {
+        syncManualMediaServerToCollectionDB: (
+          ruleGroup: {
+            id: number;
+            collectionId: number;
+          },
+          touchedMediaServerIds: Set<string>,
+        ) => Promise<void>;
+      }
+    ).syncManualMediaServerToCollectionDB(
+      { id: 10, collectionId: 1 },
+      new Set(['m-stale']), // item was touched by rule execution
+    );
+
+    // Should NOT be re-added as manual
+    expect(collectionService.addToCollection).not.toHaveBeenCalled();
+  });
+
   it('emits failed and skips execution when rule group has no library assigned', async () => {
     const { service, rulesService, eventEmitter, progressManager } =
       createService(MediaServerType.JELLYFIN);

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -250,6 +250,12 @@ export class RuleExecutorService {
             if (child && child.id) {
               const childId = child.id.toString();
 
+              // Skip items that were just added/removed by rule execution.
+              // The media server API may still return stale children after removal.
+              if (touchedMediaServerIds.has(childId)) {
+                continue;
+              }
+
               // Skip items that are excluded
               if (
                 excludedMediaServerIds.has(childId) ||


### PR DESCRIPTION
## Problem

After PR #2429 introduced `touchedMediaServerIds` to prevent `syncManualMediaServerToCollectionDB()` from double-handling items that were just processed by rule execution, the guard was only applied to the **manually removed** loop — not the **manually added** loop.

### Race condition

1. `handleCollection()` removes item X (rule evaluated false) — deletes from both DB and media server collection
2. `syncManualMediaServerToCollectionDB()` runs immediately after
3. DB correctly shows X is gone, **but** `getCollectionChildren()` may still return X from the media server API (sync delay — especially on Jellyfin, but also possible on Plex)
4. X is in media server children but not in DB → **re-added as a manual addition**

## Fix

Add the `touchedMediaServerIds` guard to the manually-added loop (mirroring the existing guard in the removal loop), so items just processed by rules are skipped and not mistakenly treated as manual additions.

## Testing

- Added regression test: `does not re-add a rule-removed item as manual when media server returns stale children`
- All 494 existing tests continue to pass