### PR TITLE
fix(ui): include server names in servarr test requests

### DIFF
--- a/apps/ui/src/components/Settings/Radarr/SettingsModal/index.tsx
+++ b/apps/ui/src/components/Settings/Radarr/SettingsModal/index.tsx
@@ -170,7 +170,7 @@ const RadarrSettingsModal = (props: IRadarrSettingsModal) => {
     const radarrUrl = constructUrl(port)
 
     await PostApiHandler<RadarrSettingTestResponse>('/settings/test/radarr', {
-      serverName,
+      serverName: serverName,
       apiKey: apiKey,
       url: `${radarrUrl}${baseUrl ? `/${baseUrl}` : ''}`,
     })

--- a/apps/ui/src/components/Settings/Sonarr/SettingsModal/index.tsx
+++ b/apps/ui/src/components/Settings/Sonarr/SettingsModal/index.tsx
@@ -170,7 +170,7 @@ const SonarrSettingsModal = (props: ISonarrSettingsModal) => {
     const sonarrUrl = constructUrl(port)
 
     await PostApiHandler<SonarrSettingTestResponse>('/settings/test/sonarr', {
-      serverName,
+      serverName: serverName,
       apiKey: apiKey,
       url: `${sonarrUrl}${baseUrl ? `/${baseUrl}` : ''}`,
     })


### PR DESCRIPTION
## Summary

Include `serverName` in Radarr and Sonarr test requests so the UI matches the current validated payload shape on `main`.

## Changes

- add `serverName` to the Radarr test request
- add `serverName` to the Sonarr test request

## Validation

- `yarn workspace @maintainerr/ui build`