### PR TITLE
fix(ui): preserve schemed servarr host input

### DIFF
--- a/apps/ui/src/components/Settings/Radarr/SettingsModal/index.tsx
+++ b/apps/ui/src/components/Settings/Radarr/SettingsModal/index.tsx
@@ -98,13 +98,11 @@ const RadarrSettingsModal = (props: IRadarrSettingsModal) => {
     !testResult?.status
 
   const constructUrl = (port: string) => {
-    const hostnameVal = hostname.includes('http://')
+    const hostnameVal = hostname.includes('://')
       ? hostname
-      : hostname.includes('https://')
-        ? hostname
-        : port == '443'
-          ? 'https://' + hostname
-          : 'http://' + hostname
+      : port == '443'
+        ? 'https://' + hostname
+        : 'http://' + hostname
 
     let radarrUrl = `${addPortToUrl(hostnameVal, +port)}`
     radarrUrl = radarrUrl.endsWith('/') ? radarrUrl.slice(0, -1) : radarrUrl

--- a/apps/ui/src/components/Settings/Sonarr/SettingsModal/index.tsx
+++ b/apps/ui/src/components/Settings/Sonarr/SettingsModal/index.tsx
@@ -98,13 +98,11 @@ const SonarrSettingsModal = (props: ISonarrSettingsModal) => {
     !testResult?.status
 
   const constructUrl = (port: string) => {
-    const hostnameVal = hostname.includes('http://')
+    const hostnameVal = hostname.includes('://')
       ? hostname
-      : hostname.includes('https://')
-        ? hostname
-        : port == '443'
-          ? 'https://' + hostname
-          : 'http://' + hostname
+      : port == '443'
+        ? 'https://' + hostname
+        : 'http://' + hostname
 
     let sonarrUrl = `${addPortToUrl(hostnameVal, +port)}`
     sonarrUrl = sonarrUrl.endsWith('/') ? sonarrUrl.slice(0, -1) : sonarrUrl


### PR DESCRIPTION
## Summary

Preserve already-schemed Radarr and Sonarr host input instead of rewriting it to `http://...` before sending it to the backend.

## Changes

- keep any `://` host input unchanged in the Radarr settings modal
- keep any `://` host input unchanged in the Sonarr settings modal
- continue prefixing bare hosts and IPs with `http://` or `https://` based on the selected port

## Why

This lets backend validation reject unsupported schemes like `ftp://` or `httpd://` directly instead of having the UI turn them into malformed `http://...` URLs.

## Validation

- `yarn workspace @maintainerr/ui build`