### PR TITLE
fix: avoid regex backtracking in disk path normalization

### DIFF
--- a/packages/contracts/src/rules/arrDiskspaceResource.ts
+++ b/packages/contracts/src/rules/arrDiskspaceResource.ts
@@ -12,5 +12,29 @@ export interface ArrDiskspaceResource {
 }
 
 export const normalizeDiskPath = (path: string): string => {
-  return path.length <= 1 ? path : path.replace(/[\\/]+$/, '')
+  if (path.length <= 1) {
+    return path
+  }
+
+  const firstCharacter = path.charCodeAt(0)
+  const isDriveLetter =
+    (firstCharacter >= 65 && firstCharacter <= 90) ||
+    (firstCharacter >= 97 && firstCharacter <= 122)
+  const minimumLengthToPreserve =
+    isDriveLetter && path[1] === ':' && (path[2] === '/' || path[2] === '\\')
+      ? 3
+      : 1
+
+  let endIndex = path.length
+
+  while (endIndex > minimumLengthToPreserve) {
+    const character = path[endIndex - 1]
+    if (character !== '/' && character !== '\\') {
+      break
+    }
+
+    endIndex -= 1
+  }
+
+  return endIndex === path.length ? path : path.slice(0, endIndex)
 }


### PR DESCRIPTION
## Summary
- replace trailing-separator regex path normalization with a linear character scan
- preserve Linux root paths and Windows drive roots while trimming redundant trailing separators
- keep disk path matching behavior suitable for Docker, Linux, Windows, and UNC-style filesystem paths

## Validation
- yarn test
- yarn check-types
- exhaustive finite path-combination sweep in chat for normalization invariants
- long-input benchmark confirmed the regex backtracking surface is removed