### PR TITLE
perf(ui): lazy-load routes and heavy UI dependencies

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,6 +130,7 @@ yarn workspace @maintainerr/contracts build
 
 - **Routing**: React Router with `createBrowserRouter` for declarative routing
 - **Routes**: Explicit route configuration in `/src/router.tsx` with nested route support
+- **Lazy Loading**: Prefer route-level lazy loading for non-shell pages and lazy-load heavy optional UI dependencies such as Monaco-backed editors or markdown renderers behind shared loading boundaries
 - **Components**: Reusable UI components in `/src/components`
 - **Hooks**: Custom hooks for data fetching (TanStack Query) and navigation (useNavigate, useLocation)
 - **Forms**: React Hook Form with Zod resolvers

--- a/apps/ui/src/api/rules.ts
+++ b/apps/ui/src/api/rules.ts
@@ -13,7 +13,7 @@ import {
 } from '@tanstack/react-query'
 import type { IRule } from '../components/Rules/Rule/RuleCreator'
 import type { IRuleGroup } from '../components/Rules/RuleGroup'
-import { AgentConfiguration } from '../components/Settings/Notifications/CreateNotificationModal'
+import type { AgentConfiguration } from '../components/Settings/Notifications/CreateNotificationModal'
 import { IConstants } from '../contexts/constants-context'
 import GetApiHandler, {
   PostApiHandler,

--- a/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/CollectionInfo/index.tsx
@@ -12,7 +12,6 @@ import {
   ECollectionLogType,
   isMetaActionedByRule,
 } from '@maintainerr/contracts'
-import { Editor } from '@monaco-editor/react'
 import { debounce } from 'lodash-es'
 import { useEffect, useRef, useState } from 'react'
 import YAML from 'yaml'
@@ -22,6 +21,7 @@ import { useRequestGeneration } from '../../../../hooks/useRequestGeneration'
 import GetApiHandler from '../../../../utils/ApiHandler'
 import Alert from '../../../Common/Alert'
 import Badge from '../../../Common/Badge'
+import LazyMonacoEditor from '../../../Common/LazyMonacoEditor'
 import LoadingSpinner, {
   SmallLoadingSpinner,
 } from '../../../Common/LoadingSpinner'
@@ -472,7 +472,7 @@ const LogMetaModal = (props: LogMetaModalProps) => {
             Output
           </label>
           <div className="editor-container h-full">
-            <Editor
+            <LazyMonacoEditor
               options={{ readOnly: true, minimap: { enabled: false } }}
               defaultLanguage="yaml"
               theme="vs-dark"

--- a/apps/ui/src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionDetail/TestMediaItem/index.tsx
@@ -1,5 +1,4 @@
 import { ClipboardCopyIcon } from '@heroicons/react/solid'
-import { Editor } from '@monaco-editor/react'
 import { useMemo, useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 import YAML from 'yaml'
@@ -7,6 +6,7 @@ import { useRuleGroupForCollection } from '../../../../api/rules'
 import GetApiHandler, { PostApiHandler } from '../../../../utils/ApiHandler'
 import Alert from '../../../Common/Alert'
 import FormItem from '../../../Common/FormItem'
+import LazyMonacoEditor from '../../../Common/LazyMonacoEditor'
 import Modal from '../../../Common/Modal'
 import SearchMediaItem, { IMediaOptions } from '../../../Common/SearchMediaITem'
 
@@ -296,7 +296,7 @@ const TestMediaItem = (props: ITestMediaItem) => {
             )}
           </div>
           <div className="editor-container h-full">
-            <Editor
+            <LazyMonacoEditor
               options={{ readOnly: true, minimap: { enabled: false } }}
               defaultLanguage="yaml"
               theme="vs-dark"

--- a/apps/ui/src/components/Collection/CollectionItem/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionItem/index.tsx
@@ -34,6 +34,8 @@ const CollectionItem = (props: ICollectionItem) => {
               height="800"
               src={`https://image.tmdb.org/t/p/w500${props.collection.media[0].image_path}`}
               alt="img"
+              loading="lazy"
+              decoding="async"
             />
             <img
               className="backdrop-image"
@@ -41,6 +43,8 @@ const CollectionItem = (props: ICollectionItem) => {
               height="800"
               src={`https://image.tmdb.org/t/p/w500/${props.collection.media[1].image_path}`}
               alt="img"
+              loading="lazy"
+              decoding="async"
             />
             <div className="collection-backdrop"></div>
           </div>

--- a/apps/ui/src/components/Common/LazyBoundary.tsx
+++ b/apps/ui/src/components/Common/LazyBoundary.tsx
@@ -1,0 +1,16 @@
+import { Suspense, type ReactNode } from 'react'
+import LoadingSpinner from './LoadingSpinner'
+
+interface LazyBoundaryProps {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+const LazyBoundary = ({
+  children,
+  fallback = <LoadingSpinner />,
+}: LazyBoundaryProps) => {
+  return <Suspense fallback={fallback}>{children}</Suspense>
+}
+
+export default LazyBoundary

--- a/apps/ui/src/components/Common/LazyModalBoundary.tsx
+++ b/apps/ui/src/components/Common/LazyModalBoundary.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from 'react'
+import LazyBoundary from './LazyBoundary'
+import Modal from './Modal'
+
+interface LazyModalBoundaryProps {
+  children: ReactNode
+  onCancel?: () => void
+  title?: string
+  size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl'
+  backgroundClickable?: boolean
+}
+
+const LazyModalBoundary = ({
+  children,
+  onCancel,
+  title,
+  size,
+  backgroundClickable,
+}: LazyModalBoundaryProps) => {
+  return (
+    <LazyBoundary
+      fallback={
+        <Modal
+          loading
+          title={title}
+          size={size}
+          onCancel={onCancel}
+          backgroundClickable={backgroundClickable}
+        >
+          <div />
+        </Modal>
+      }
+    >
+      {children}
+    </LazyBoundary>
+  )
+}
+
+export default LazyModalBoundary

--- a/apps/ui/src/components/Common/LazyMonacoEditor.tsx
+++ b/apps/ui/src/components/Common/LazyMonacoEditor.tsx
@@ -1,0 +1,23 @@
+import { lazy, type ComponentProps } from 'react'
+import LazyBoundary from './LazyBoundary'
+import LoadingSpinner from './LoadingSpinner'
+
+const MonacoEditor = lazy(() => import('@monaco-editor/react'))
+
+type LazyMonacoEditorProps = ComponentProps<typeof MonacoEditor>
+
+const LazyMonacoEditor = (props: LazyMonacoEditorProps) => {
+  return (
+    <LazyBoundary
+      fallback={
+        <div className="flex h-full min-h-48 items-center justify-center">
+          <LoadingSpinner />
+        </div>
+      }
+    >
+      <MonacoEditor {...props} />
+    </LazyBoundary>
+  )
+}
+
+export default LazyMonacoEditor

--- a/apps/ui/src/components/Common/MediaCard/index.tsx
+++ b/apps/ui/src/components/Common/MediaCard/index.tsx
@@ -53,12 +53,12 @@ const MediaCard: React.FC<IMediaCard> = ({
   }>({ requestKey: undefined, path: null })
   const [excludeModal, setExcludeModal] = useState(false)
   const [addModal, setAddModal] = useState(false)
-  const [hasExclusion, setHasExclusion] = useState(false)
   const [showMediaModal, setShowMediaModal] = useState(false)
   const imageType = ['season', 'episode'].includes(mediaType)
     ? 'show'
     : mediaType
   const imageRequestKey = tmdbid ? `${imageType}:${tmdbid}` : undefined
+  const hasExclusion = exclusionId !== undefined || exclusionType !== undefined
 
   const openMediaModal = () => {
     setShowMediaModal(true)
@@ -81,22 +81,6 @@ const MediaCard: React.FC<IMediaCard> = ({
       isActive = false
     }
   }, [imageRequestKey, imageType, tmdbid])
-
-  useEffect(() => {
-    let isActive = true
-
-    if (!collectionPage) {
-      GetApiHandler(`/rules/exclusion?mediaServerId=${id}`).then((resp: []) => {
-        if (isActive) {
-          setHasExclusion(resp.length > 0)
-        }
-      })
-    }
-
-    return () => {
-      isActive = false
-    }
-  }, [collectionPage, id])
 
   const image =
     imageResult.requestKey === imageRequestKey ? imageResult.path : null
@@ -153,6 +137,8 @@ const MediaCard: React.FC<IMediaCard> = ({
               className="absolute inset-0 h-full w-full object-cover"
               alt=""
               src={`https://image.tmdb.org/t/p/w300_and_h450_face${image}`}
+              loading="lazy"
+              decoding="async"
             />
           ) : undefined}
           <div className="absolute left-0 right-0 flex items-center justify-between p-2">

--- a/apps/ui/src/components/Common/TabbedLinks/index.tsx
+++ b/apps/ui/src/components/Common/TabbedLinks/index.tsx
@@ -11,6 +11,7 @@ export interface ItabbedLinks {
   allEnabled?: boolean
   currentRoute?: string
   onChange: (target: string) => void
+  onPrefetch?: (target: string) => void
 }
 
 export interface ITabbedLink {
@@ -20,6 +21,7 @@ export interface ITabbedLink {
   disabled?: boolean
   children?: ReactNode
   onClick: (path: string) => void
+  onPrefetch?: (path: string) => void
 }
 
 const TabbedLink = (props: ITabbedLink) => {
@@ -32,6 +34,9 @@ const TabbedLink = (props: ITabbedLink) => {
 
   return (
     <a
+      onMouseEnter={() => props.onPrefetch?.(props.route)}
+      onFocus={() => props.onPrefetch?.(props.route)}
+      onTouchStart={() => props.onPrefetch?.(props.route)}
       onClick={() => props.onClick(props.route)}
       className={`${linkClasses} ${
         props.currentRoute.match(props.route)
@@ -53,6 +58,7 @@ const TabbedLinks = (props: ItabbedLinks) => {
           {props.routes.map((route, index) => (
             <TabbedLink
               onClick={(r) => props.onChange(r)}
+              onPrefetch={(r) => props.onPrefetch?.(r)}
               route={route.route}
               disabled={!props.allEnabled}
               currentRoute={

--- a/apps/ui/src/components/Common/YamlImporterModal/index.tsx
+++ b/apps/ui/src/components/Common/YamlImporterModal/index.tsx
@@ -1,9 +1,9 @@
 import { UploadIcon } from '@heroicons/react/outline'
 import { ClipboardCopyIcon } from '@heroicons/react/solid'
-import Editor from '@monaco-editor/react'
 import { useRef } from 'react'
 import { toast } from 'react-toastify'
 import Alert from '../Alert'
+import LazyMonacoEditor from '../LazyMonacoEditor'
 import Modal from '../Modal'
 
 export interface IYamlImporterModal {
@@ -143,7 +143,7 @@ const YamlImporterModal = (props: IYamlImporterModal) => {
             </button>
           )}
         </div>
-        <Editor
+        <LazyMonacoEditor
           options={{
             minimap: { enabled: false },
             ...(props.yaml ? { readOnly: true } : undefined),

--- a/apps/ui/src/components/Layout/NavBar/index.tsx
+++ b/apps/ui/src/components/Layout/NavBar/index.tsx
@@ -9,6 +9,7 @@ import {
 import { ReactNode, useContext, useMemo, useRef } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import SearchContext from '../../../contexts/search-context'
+import { prefetchRoute } from '../../../router'
 import Messages from '../../Messages/Messages'
 import VersionStatus from '../../VersionStatus'
 
@@ -75,6 +76,10 @@ const NavBar: React.FC<NavBarProps> = ({ open, setClosed }) => {
     return location.pathname === link.href
   }
 
+  const handlePrefetch = (path: string) => {
+    void prefetchRoute(path)
+  }
+
   return (
     <div>
       <div className="lg:hidden">
@@ -115,6 +120,9 @@ const NavBar: React.FC<NavBarProps> = ({ open, setClosed }) => {
                         <Link
                           key={link.key}
                           to={link.href}
+                          onMouseEnter={() => handlePrefetch(link.href)}
+                          onFocus={() => handlePrefetch(link.href)}
+                          onTouchStart={() => handlePrefetch(link.href)}
                           onClick={() => {
                             if (link.href === '/overview') {
                               SearchCtx.removeText()
@@ -170,6 +178,9 @@ const NavBar: React.FC<NavBarProps> = ({ open, setClosed }) => {
                     <Link
                       key={`desktop-${navBarLink.key}`}
                       to={navBarLink.href}
+                      onMouseEnter={() => handlePrefetch(navBarLink.href)}
+                      onFocus={() => handlePrefetch(navBarLink.href)}
+                      onTouchStart={() => handlePrefetch(navBarLink.href)}
                       onClick={() => {
                         if (navBarLink.href === '/overview') {
                           SearchCtx.removeText()

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useEffectEvent, useState } from 'react'
 import GetApiHandler from '../../../../../utils/ApiHandler'
 import { IRadarrSetting } from '../../../../Settings/Radarr'
 import { ISonarrSetting } from '../../../../Settings/Sonarr'
@@ -57,8 +57,12 @@ const ArrAction = (props: ArrActionProps) => {
     }
   }
 
+  const syncArrSettings = useEffectEvent((type: ArrType) => {
+    void loadArrSettings(type)
+  })
+
   useEffect(() => {
-    loadArrSettings(props.type)
+    syncArrSettings(props.type)
   }, [props.type])
 
   const noneServerSelected = selectedSetting === ''

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/ConfigureNotificationModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/ConfigureNotificationModal/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import GetApiHandler from '../../../../../utils/ApiHandler'
 import Modal from '../../../../Common/Modal'
 import ToggleItem from '../../../../Common/ToggleButton'
-import { AgentConfiguration } from '../../../../Settings/Notifications/CreateNotificationModal'
+import type { AgentConfiguration } from '../../../../Settings/Notifications/CreateNotificationModal'
 
 interface ConfigureNotificationModal {
   onCancel: () => void

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -16,7 +16,7 @@ import {
   MediaLibrary,
 } from '@maintainerr/contracts'
 import { isValidCron } from 'cron-validator'
-import { useState, useSyncExternalStore } from 'react'
+import { lazy, useState, useSyncExternalStore } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'react-toastify'
@@ -35,12 +35,18 @@ import { logClientError } from '../../../../utils/ClientLogger'
 import Alert from '../../../Common/Alert'
 import Button from '../../../Common/Button'
 import CommunityRuleModal from '../../../Common/CommunityRuleModal'
+import LazyModalBoundary from '../../../Common/LazyModalBoundary'
 import LoadingSpinner from '../../../Common/LoadingSpinner'
-import YamlImporterModal from '../../../Common/YamlImporterModal'
-import { AgentConfiguration } from '../../../Settings/Notifications/CreateNotificationModal'
+import type { AgentConfiguration } from '../../../Settings/Notifications/CreateNotificationModal'
 import RuleCreator, { IRule } from '../../Rule/RuleCreator'
 import ArrAction from './ArrAction'
-import ConfigureNotificationModal from './ConfigureNotificationModal'
+
+const YamlImporterModal = lazy(
+  () => import('../../../Common/YamlImporterModal'),
+)
+const ConfigureNotificationModal = lazy(
+  () => import('./ConfigureNotificationModal'),
+)
 
 interface AddModal {
   editData?: IRuleGroup
@@ -1293,29 +1299,44 @@ const AddModal = (props: AddModal) => {
                   />
                 )}
                 {yamlImporterModal && (
-                  <YamlImporterModal
-                    yaml={yaml}
-                    onImport={(yaml: string) => {
-                      importRulesFromYaml(yaml)
-                      setYamlImporterModal(false)
-                    }}
+                  <LazyModalBoundary
+                    title={yaml ? 'Export Rules YAML' : 'Import Rules YAML'}
                     onCancel={() => {
                       setYamlImporterModal(false)
                     }}
-                  />
+                    size="5xl"
+                  >
+                    <YamlImporterModal
+                      yaml={yaml}
+                      onImport={(yaml: string) => {
+                        importRulesFromYaml(yaml)
+                        setYamlImporterModal(false)
+                      }}
+                      onCancel={() => {
+                        setYamlImporterModal(false)
+                      }}
+                    />
+                  </LazyModalBoundary>
                 )}
 
                 {configureNotificionModal && (
-                  <ConfigureNotificationModal
-                    onSuccess={(selection) => {
-                      setConfiguredNotificationConfigurations(selection)
-                      setConfigureNotificationModal(false)
-                    }}
+                  <LazyModalBoundary
+                    title="Configure Notifications"
                     onCancel={() => {
                       setConfigureNotificationModal(false)
                     }}
-                    selectedAgents={configuredNotificationConfigurations}
-                  />
+                  >
+                    <ConfigureNotificationModal
+                      onSuccess={(selection) => {
+                        setConfiguredNotificationConfigurations(selection)
+                        setConfigureNotificationModal(false)
+                      }}
+                      onCancel={() => {
+                        setConfigureNotificationModal(false)
+                      }}
+                      selectedAgents={configuredNotificationConfigurations}
+                    />
+                  </LazyModalBoundary>
                 )}
 
                 <RuleCreator

--- a/apps/ui/src/components/Rules/RuleGroup/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/index.tsx
@@ -20,7 +20,7 @@ import { logClientError } from '../../../utils/ClientLogger'
 import { ICollection } from '../../Collection'
 import DeleteButton from '../../Common/DeleteButton'
 import EditButton from '../../Common/EditButton'
-import { AgentConfiguration } from '../../Settings/Notifications/CreateNotificationModal'
+import type { AgentConfiguration } from '../../Settings/Notifications/CreateNotificationModal'
 import { IRuleJson } from '../Rule'
 
 export interface IRuleGroup {

--- a/apps/ui/src/components/Settings/About/Releases/index.tsx
+++ b/apps/ui/src/components/Settings/About/Releases/index.tsx
@@ -1,7 +1,8 @@
-import { lazy, Suspense, useEffect, useState } from 'react'
+import { lazy, useEffect, useState } from 'react'
 import GetApiHandler from '../../../../utils/ApiHandler'
 import Badge from '../../../Common/Badge'
 import Button from '../../../Common/Button'
+import LazyBoundary from '../../../Common/LazyBoundary'
 import LoadingSpinner from '../../../Common/LoadingSpinner'
 import Modal from '../../../Common/Modal'
 
@@ -75,9 +76,9 @@ const Release = ({ currentVersion, release, isLatest }: ReleaseProps) => {
             }}
           >
             <div className="prose:sm prose">
-              <Suspense fallback={<LoadingSpinner />}>
+              <LazyBoundary>
                 <ReactMarkdown>{release.body}</ReactMarkdown>
-              </Suspense>
+              </LazyBoundary>
             </div>
           </Modal>
         </div>

--- a/apps/ui/src/components/Settings/Notifications/CreateNotificationModal/index.tsx
+++ b/apps/ui/src/components/Settings/Notifications/CreateNotificationModal/index.tsx
@@ -1,9 +1,9 @@
 import { BasicResponseDto } from '@maintainerr/contracts'
-import { Editor } from '@monaco-editor/react'
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 import GetApiHandler, { PostApiHandler } from '../../../../utils/ApiHandler'
 import { camelCaseToPrettyText } from '../../../../utils/SettingsUtils'
+import LazyMonacoEditor from '../../../Common/LazyMonacoEditor'
 import LoadingSpinner from '../../../Common/LoadingSpinner'
 import Modal from '../../../Common/Modal'
 import ToggleItem from '../../../Common/ToggleButton'
@@ -259,7 +259,7 @@ const CreateNotificationModal = (props: CreateNotificationModal) => {
                     <div className="form-input">
                       <div className="form-input-field">
                         {option.type === 'json' ? (
-                          <Editor
+                          <LazyMonacoEditor
                             height="200px"
                             defaultLanguage="json"
                             theme="vs-dark"

--- a/apps/ui/src/components/Settings/Notifications/index.tsx
+++ b/apps/ui/src/components/Settings/Notifications/index.tsx
@@ -4,13 +4,14 @@ import {
   TrashIcon,
 } from '@heroicons/react/solid'
 
-import { useEffect, useState } from 'react'
+import { lazy, useEffect, useState } from 'react'
 import { toast } from 'react-toastify'
 import GetApiHandler, { DeleteApiHandler } from '../../../utils/ApiHandler'
 import Button from '../../Common/Button'
-import CreateNotificationModal, {
-  AgentConfiguration,
-} from './CreateNotificationModal'
+import LazyModalBoundary from '../../Common/LazyModalBoundary'
+import type { AgentConfiguration } from './CreateNotificationModal'
+
+const CreateNotificationModal = lazy(() => import('./CreateNotificationModal'))
 
 const NotificationSettings = () => {
   const [addModalActive, setAddModalActive] = useState(false)
@@ -119,35 +120,47 @@ const NotificationSettings = () => {
         </div>
 
         {addModalActive ? (
-          <CreateNotificationModal
+          <LazyModalBoundary
+            title={
+              editConfig
+                ? 'Edit Notification Agent'
+                : 'Create Notification Agent'
+            }
             onCancel={() => {
               updateAddModalActive(!addModalActive)
               setEditConfig(undefined)
             }}
-            onSave={(bool) => {
-              updateAddModalActive(!addModalActive)
-              setEditConfig(undefined)
-              if (bool) {
-                toast.success('Successfully saved notification agent')
-              } else {
-                toast.error("Didn't save incomplete notification agent")
-              }
-            }}
-            onTest={() => {}}
-            {...(editConfig
-              ? {
-                  selected: {
-                    id: editConfig.id!,
-                    name: editConfig.name!,
-                    enabled: editConfig.enabled!,
-                    agent: editConfig.agent!,
-                    types: editConfig.types!,
-                    options: editConfig.options!,
-                    aboutScale: editConfig.aboutScale!,
-                  },
+          >
+            <CreateNotificationModal
+              onCancel={() => {
+                updateAddModalActive(!addModalActive)
+                setEditConfig(undefined)
+              }}
+              onSave={(bool) => {
+                updateAddModalActive(!addModalActive)
+                setEditConfig(undefined)
+                if (bool) {
+                  toast.success('Successfully saved notification agent')
+                } else {
+                  toast.error("Didn't save incomplete notification agent")
                 }
-              : {})}
-          />
+              }}
+              onTest={() => {}}
+              {...(editConfig
+                ? {
+                    selected: {
+                      id: editConfig.id!,
+                      name: editConfig.name!,
+                      enabled: editConfig.enabled!,
+                      agent: editConfig.agent!,
+                      types: editConfig.types!,
+                      options: editConfig.options!,
+                      aboutScale: editConfig.aboutScale!,
+                    },
+                  }
+                : {})}
+            />
+          </LazyModalBoundary>
         ) : null}
       </div>
     </>

--- a/apps/ui/src/components/Settings/Tabs/index.tsx
+++ b/apps/ui/src/components/Settings/Tabs/index.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useEffect } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { prefetchRoute } from '../../../router'
 
 export interface SettingsRoute {
   text: string
@@ -44,6 +45,9 @@ const SettingsLink: React.FC<ISettingsLink> = (props: ISettingsLink) => {
   return (
     <Link
       to={props.route}
+      onMouseEnter={() => void prefetchRoute(props.route)}
+      onFocus={() => void prefetchRoute(props.route)}
+      onTouchStart={() => void prefetchRoute(props.route)}
       className={`${linkClasses} ${
         props.currentPath.match(props.regex)
           ? activeLinkColor
@@ -88,7 +92,13 @@ const SettingsTabs: React.FC<{
         </label>
         <select
           value={currentRoute}
+          onFocus={() => {
+            if (currentRoute) {
+              void prefetchRoute(currentRoute)
+            }
+          }}
           onChange={(e) => {
+            void prefetchRoute(e.target.value)
             navigate(e.target.value)
           }}
           onBlur={(e) => {

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import 'react-toastify/dist/ReactToastify.css'
 import '../styles/globals.css'
+import LoadingSpinner from './components/Common/LoadingSpinner'
 import { EventsProvider } from './contexts/events-context'
 import { SearchContextProvider } from './contexts/search-context'
 import { TaskStatusProvider } from './contexts/taskstatus-context'
@@ -17,7 +18,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <EventsProvider>
         <TaskStatusProvider>
           <SearchContextProvider>
-            <RouterProvider router={router} />
+            <RouterProvider
+              router={router}
+              fallbackElement={<LoadingSpinner />}
+            />
           </SearchContextProvider>
         </TaskStatusProvider>
       </EventsProvider>

--- a/apps/ui/src/pages/CollectionDetailPage.tsx
+++ b/apps/ui/src/pages/CollectionDetailPage.tsx
@@ -1,15 +1,20 @@
 import { PlayIcon } from '@heroicons/react/solid'
-import { useEffect, useState } from 'react'
+import { lazy, useEffect, useEffectEvent, useState } from 'react'
 import { Outlet, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import { useRuleGroupForCollection } from '../api/rules'
 import { ICollection } from '../components/Collection'
-import TestMediaItem from '../components/Collection/CollectionDetail/TestMediaItem'
+import LazyModalBoundary from '../components/Common/LazyModalBoundary'
 import LoadingSpinner from '../components/Common/LoadingSpinner'
 import TabbedLinks, { TabbedRoute } from '../components/Common/TabbedLinks'
 import { useRequestGeneration } from '../hooks/useRequestGeneration'
+import { prefetchRoute } from '../router'
 import GetApiHandler from '../utils/ApiHandler'
 import { logClientError } from '../utils/ClientLogger'
+
+const TestMediaItem = lazy(
+  () => import('../components/Collection/CollectionDetail/TestMediaItem'),
+)
 
 const CollectionDetailPage = () => {
   const navigate = useNavigate()
@@ -54,10 +59,14 @@ const CollectionDetailPage = () => {
     }
   }
 
+  const loadCollection = useEffectEvent((collectionId: string) => {
+    invalidate()
+    void fetchData(collectionId)
+  })
+
   useEffect(() => {
     if (id) {
-      invalidate()
-      fetchData(id)
+      loadCollection(id)
     }
   }, [id])
 
@@ -84,6 +93,19 @@ const CollectionDetailPage = () => {
     }
   }
 
+  const handleTabPrefetch = (tab: string) => {
+    if (!id) {
+      return
+    }
+
+    if (tab === 'media') {
+      void prefetchRoute(`/collections/${id}`)
+      return
+    }
+
+    void prefetchRoute(`/collections/${id}/${tab}`)
+  }
+
   if (isLoading || !collection || ruleGroupLoading) {
     return (
       <>
@@ -108,6 +130,7 @@ const CollectionDetailPage = () => {
             <div className="mb-4 mt-0 w-fit sm:w-full">
               <TabbedLinks
                 onChange={handleTabChange}
+                onPrefetch={handleTabPrefetch}
                 routes={tabbedRoutes}
                 currentRoute={currentTab}
                 allEnabled={true}
@@ -130,13 +153,21 @@ const CollectionDetailPage = () => {
         </div>
 
         {mediaTestModalOpen && collection?.id ? (
-          <TestMediaItem
-            collectionId={+collection.id}
+          <LazyModalBoundary
+            title="Test Media"
             onCancel={() => {
               setMediaTestModalOpen(false)
             }}
-            onSubmit={() => {}}
-          />
+            size="5xl"
+          >
+            <TestMediaItem
+              collectionId={+collection.id}
+              onCancel={() => {
+                setMediaTestModalOpen(false)
+              }}
+              onSubmit={() => {}}
+            />
+          </LazyModalBoundary>
         ) : undefined}
       </div>
     </>

--- a/apps/ui/src/pages/RulesListPage.tsx
+++ b/apps/ui/src/pages/RulesListPage.tsx
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios'
-import { useEffect, useState } from 'react'
+import { useEffect, useEffectEvent, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'react-toastify'
 import { useStopAllRuleExecution } from '../api/rules'
@@ -45,8 +45,12 @@ const RulesListPage = () => {
     }
   }
 
+  const syncRulesForLibrary = useEffectEvent((libraryId: string) => {
+    void fetchData(libraryId)
+  })
+
   useEffect(() => {
-    fetchData(selectedLibrary)
+    syncRulesForLibrary(selectedLibrary)
   }, [selectedLibrary])
 
   const onSwitchLibrary = (libraryId: string) => {
@@ -56,7 +60,7 @@ const RulesListPage = () => {
 
   const refreshData = (): void => {
     invalidate()
-    fetchData(selectedLibrary)
+    void fetchData(selectedLibrary)
   }
 
   const editHandler = (group: IRuleGroup): void => {

--- a/apps/ui/src/router.tsx
+++ b/apps/ui/src/router.tsx
@@ -1,28 +1,349 @@
+import type { ComponentType } from 'react'
 import { createBrowserRouter, Navigate } from 'react-router-dom'
 import Layout, { LayoutErrorBoundary } from './components/Layout'
 import Overview from './components/Overview'
+// Settings is kept eager because it wraps an <Outlet /> — making it lazy
+// would cause two sequential fetches (wrapper then child) on every settings navigation.
 import Settings from './components/Settings'
-import SettingsAbout from './components/Settings/About'
-import SettingsJellyfin from './components/Settings/Jellyfin'
-import SettingsSeerr from './components/Settings/Seerr'
-import SettingsJobs from './components/Settings/Jobs'
-import SettingsLogs from './components/Settings/Logs'
-import SettingsMain from './components/Settings/Main'
-import SettingsNotifications from './components/Settings/Notifications'
-import SettingsPlex from './components/Settings/Plex'
-import SettingsRadarr from './components/Settings/Radarr'
-import SettingsSonarr from './components/Settings/Sonarr'
-import SettingsTautulli from './components/Settings/Tautulli'
-import CollectionDetailPage from './pages/CollectionDetailPage'
-import CollectionExclusionsPage from './pages/CollectionExclusionsPage'
-import CollectionInfoPage from './pages/CollectionInfoPage'
-import CollectionMediaPage from './pages/CollectionMediaPage'
-import CollectionsListPage from './pages/CollectionsListPage'
-import DocsPage from './pages/DocsPage'
-import RuleFormPage from './pages/RuleFormPage'
-import RulesListPage from './pages/RulesListPage'
 
 const basePath = import.meta.env.VITE_BASE_PATH || ''
+
+type LazyRouteModule = {
+  default: ComponentType
+}
+
+type LazyRoute = {
+  lazy: () => Promise<{ Component: ComponentType }>
+  preload: () => Promise<LazyRouteModule>
+}
+
+const createLazyRoute = <T extends LazyRouteModule>(
+  importer: () => Promise<T>,
+): LazyRoute => {
+  let promise: Promise<T> | undefined
+
+  const preload = () => {
+    if (!promise) {
+      promise = importer().catch((error) => {
+        promise = undefined
+        throw error
+      })
+    }
+
+    return promise
+  }
+
+  return {
+    lazy: async () => {
+      const { default: Component } = await preload()
+      return { Component }
+    },
+    preload,
+  }
+}
+
+const collectionsListRoute = createLazyRoute(
+  () => import('./pages/CollectionsListPage'),
+)
+const collectionDetailRoute = createLazyRoute(
+  () => import('./pages/CollectionDetailPage'),
+)
+const collectionMediaRoute = createLazyRoute(
+  () => import('./pages/CollectionMediaPage'),
+)
+const collectionExclusionsRoute = createLazyRoute(
+  () => import('./pages/CollectionExclusionsPage'),
+)
+const collectionInfoRoute = createLazyRoute(
+  () => import('./pages/CollectionInfoPage'),
+)
+const rulesListRoute = createLazyRoute(() => import('./pages/RulesListPage'))
+const ruleFormRoute = createLazyRoute(() => import('./pages/RuleFormPage'))
+const docsRoute = createLazyRoute(() => import('./pages/DocsPage'))
+const settingsMainRoute = createLazyRoute(
+  () => import('./components/Settings/Main'),
+)
+const settingsPlexRoute = createLazyRoute(
+  () => import('./components/Settings/Plex'),
+)
+const settingsJellyfinRoute = createLazyRoute(
+  () => import('./components/Settings/Jellyfin'),
+)
+const settingsSonarrRoute = createLazyRoute(
+  () => import('./components/Settings/Sonarr'),
+)
+const settingsRadarrRoute = createLazyRoute(
+  () => import('./components/Settings/Radarr'),
+)
+const settingsSeerrRoute = createLazyRoute(
+  () => import('./components/Settings/Seerr'),
+)
+const settingsTautulliRoute = createLazyRoute(
+  () => import('./components/Settings/Tautulli'),
+)
+const settingsNotificationsRoute = createLazyRoute(
+  () => import('./components/Settings/Notifications'),
+)
+const settingsJobsRoute = createLazyRoute(
+  () => import('./components/Settings/Jobs'),
+)
+const settingsLogsRoute = createLazyRoute(
+  () => import('./components/Settings/Logs'),
+)
+const settingsAboutRoute = createLazyRoute(
+  () => import('./components/Settings/About'),
+)
+
+/**
+ * Preloadable route definition — single source of truth for both
+ * the React Router config and the prefetch system. Routes that use
+ * createLazyRoute carry both `lazy` (for the router) and `preload`
+ * (for hover-prefetching) from the same object, so they can't drift.
+ */
+type AppRoute = {
+  path?: string
+  index?: boolean
+  lazy?: LazyRoute['lazy']
+  preload?: LazyRoute['preload']
+  element?: React.ReactNode
+  errorElement?: React.ReactNode
+  children?: AppRoute[]
+}
+
+const appRoutes: AppRoute[] = [
+  {
+    index: true,
+    element: <Navigate to="/overview" replace />,
+  },
+  {
+    path: 'overview',
+    element: <Overview />,
+  },
+  {
+    path: 'collections',
+    children: [
+      {
+        index: true,
+        lazy: collectionsListRoute.lazy,
+        preload: collectionsListRoute.preload,
+      },
+      {
+        path: ':id',
+        lazy: collectionDetailRoute.lazy,
+        preload: collectionDetailRoute.preload,
+        children: [
+          {
+            index: true,
+            lazy: collectionMediaRoute.lazy,
+            preload: collectionMediaRoute.preload,
+          },
+          {
+            path: 'exclusions',
+            lazy: collectionExclusionsRoute.lazy,
+            preload: collectionExclusionsRoute.preload,
+          },
+          {
+            path: 'info',
+            lazy: collectionInfoRoute.lazy,
+            preload: collectionInfoRoute.preload,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    path: 'rules',
+    children: [
+      {
+        index: true,
+        lazy: rulesListRoute.lazy,
+        preload: rulesListRoute.preload,
+      },
+      {
+        path: 'new',
+        lazy: ruleFormRoute.lazy,
+        preload: ruleFormRoute.preload,
+      },
+      {
+        path: 'edit/:id',
+        lazy: ruleFormRoute.lazy,
+        preload: ruleFormRoute.preload,
+      },
+      {
+        path: 'clone/:id',
+        lazy: ruleFormRoute.lazy,
+        preload: ruleFormRoute.preload,
+      },
+    ],
+  },
+  {
+    path: 'docs',
+    lazy: docsRoute.lazy,
+    preload: docsRoute.preload,
+  },
+  {
+    path: 'settings',
+    element: <Settings />,
+    children: [
+      {
+        index: true,
+        element: <Navigate to="/settings/main" replace />,
+        preload: settingsMainRoute.preload,
+      },
+      {
+        path: 'main',
+        lazy: settingsMainRoute.lazy,
+        preload: settingsMainRoute.preload,
+      },
+      {
+        path: 'plex',
+        lazy: settingsPlexRoute.lazy,
+        preload: settingsPlexRoute.preload,
+      },
+      {
+        path: 'jellyfin',
+        lazy: settingsJellyfinRoute.lazy,
+        preload: settingsJellyfinRoute.preload,
+      },
+      {
+        path: 'sonarr',
+        lazy: settingsSonarrRoute.lazy,
+        preload: settingsSonarrRoute.preload,
+      },
+      {
+        path: 'radarr',
+        lazy: settingsRadarrRoute.lazy,
+        preload: settingsRadarrRoute.preload,
+      },
+      {
+        path: 'seerr',
+        lazy: settingsSeerrRoute.lazy,
+        preload: settingsSeerrRoute.preload,
+      },
+      {
+        path: 'tautulli',
+        lazy: settingsTautulliRoute.lazy,
+        preload: settingsTautulliRoute.preload,
+      },
+      {
+        path: 'notifications',
+        lazy: settingsNotificationsRoute.lazy,
+        preload: settingsNotificationsRoute.preload,
+      },
+      {
+        path: 'jobs',
+        lazy: settingsJobsRoute.lazy,
+        preload: settingsJobsRoute.preload,
+      },
+      {
+        path: 'logs',
+        lazy: settingsLogsRoute.lazy,
+        preload: settingsLogsRoute.preload,
+      },
+      {
+        path: 'about',
+        lazy: settingsAboutRoute.lazy,
+        preload: settingsAboutRoute.preload,
+      },
+    ],
+  },
+]
+
+const normalizePrefetchPath = (path: string) => {
+  const trimmedPath = path.trim()
+  let endOfPath = trimmedPath.length
+
+  for (let index = 0; index < trimmedPath.length; index += 1) {
+    const character = trimmedPath[index]
+    if (character === '?' || character === '#') {
+      endOfPath = index
+      break
+    }
+  }
+
+  const pathWithoutQueryOrHash = trimmedPath.slice(0, endOfPath) || '/'
+  const normalizedPath = pathWithoutQueryOrHash.startsWith('/')
+    ? pathWithoutQueryOrHash
+    : `/${pathWithoutQueryOrHash}`
+
+  if (normalizedPath.length <= 1) {
+    return normalizedPath
+  }
+
+  let normalizedEnd = normalizedPath.length
+
+  while (normalizedEnd > 1 && normalizedPath[normalizedEnd - 1] === '/') {
+    normalizedEnd -= 1
+  }
+
+  return normalizedEnd === normalizedPath.length
+    ? normalizedPath
+    : normalizedPath.slice(0, normalizedEnd)
+}
+
+/**
+ * Walk the route tree to find all routes matching a path,
+ * collecting preload functions from every matched ancestor + leaf.
+ */
+const collectPreloaders = (
+  routes: AppRoute[],
+  segments: string[],
+): Array<() => Promise<unknown>> => {
+  const preloaders: Array<() => Promise<unknown>> = []
+
+  const walk = (nodes: AppRoute[], remaining: string[]): boolean => {
+    for (const route of nodes) {
+      if (route.index) {
+        if (remaining.length === 0) {
+          if (route.preload) preloaders.push(route.preload)
+          return true
+        }
+        continue
+      }
+
+      if (!route.path) {
+        if (route.children && walk(route.children, remaining)) {
+          if (route.preload) preloaders.push(route.preload)
+          return true
+        }
+        continue
+      }
+
+      const routeSegments = route.path.split('/').filter(Boolean)
+      if (routeSegments.length > remaining.length) continue
+
+      const matches = routeSegments.every(
+        (seg, i) => seg.startsWith(':') || seg === remaining[i],
+      )
+      if (!matches) continue
+
+      if (route.preload) preloaders.push(route.preload)
+
+      const rest = remaining.slice(routeSegments.length)
+      if (rest.length === 0) {
+        // Exact match — also preload the index child if present
+        const indexChild = route.children?.find((c) => c.index)
+        if (indexChild?.preload) preloaders.push(indexChild.preload)
+        return true
+      }
+
+      if (route.children && walk(route.children, rest)) return true
+    }
+    return false
+  }
+
+  walk(routes, segments)
+  return preloaders
+}
+
+export const prefetchRoute = (path: string) => {
+  const normalized = normalizePrefetchPath(path)
+  const segments = normalized.split('/').filter(Boolean)
+  const preloaders = collectPreloaders(appRoutes, segments)
+
+  if (preloaders.length === 0) return Promise.resolve()
+  return Promise.all(preloaders.map((fn) => fn())).then(() => undefined)
+}
 
 export const router = createBrowserRouter(
   [
@@ -30,122 +351,7 @@ export const router = createBrowserRouter(
       path: '/',
       element: <Layout />,
       errorElement: <LayoutErrorBoundary />,
-      children: [
-        {
-          index: true,
-          element: <Navigate to="/overview" replace />,
-        },
-        {
-          path: 'overview',
-          element: <Overview />,
-        },
-        {
-          path: 'collections',
-          children: [
-            {
-              index: true,
-              element: <CollectionsListPage />,
-            },
-            {
-              path: ':id',
-              element: <CollectionDetailPage />,
-              children: [
-                {
-                  index: true,
-                  element: <CollectionMediaPage />,
-                },
-                {
-                  path: 'exclusions',
-                  element: <CollectionExclusionsPage />,
-                },
-                {
-                  path: 'info',
-                  element: <CollectionInfoPage />,
-                },
-              ],
-            },
-          ],
-        },
-        {
-          path: 'rules',
-          children: [
-            {
-              index: true,
-              element: <RulesListPage />,
-            },
-            {
-              path: 'new',
-              element: <RuleFormPage />,
-            },
-            {
-              path: 'edit/:id',
-              element: <RuleFormPage />,
-            },
-            {
-              path: 'clone/:id',
-              element: <RuleFormPage />,
-            },
-          ],
-        },
-        {
-          path: 'docs',
-          element: <DocsPage />,
-        },
-        {
-          path: 'settings',
-          element: <Settings />,
-          children: [
-            {
-              index: true,
-              element: <Navigate to="/settings/main" replace />,
-            },
-            {
-              path: 'main',
-              element: <SettingsMain />,
-            },
-            {
-              path: 'plex',
-              element: <SettingsPlex />,
-            },
-            {
-              path: 'jellyfin',
-              element: <SettingsJellyfin />,
-            },
-            {
-              path: 'sonarr',
-              element: <SettingsSonarr />,
-            },
-            {
-              path: 'radarr',
-              element: <SettingsRadarr />,
-            },
-            {
-              path: 'seerr',
-              element: <SettingsSeerr />,
-            },
-            {
-              path: 'tautulli',
-              element: <SettingsTautulli />,
-            },
-            {
-              path: 'notifications',
-              element: <SettingsNotifications />,
-            },
-            {
-              path: 'jobs',
-              element: <SettingsJobs />,
-            },
-            {
-              path: 'logs',
-              element: <SettingsLogs />,
-            },
-            {
-              path: 'about',
-              element: <SettingsAbout />,
-            },
-          ],
-        },
-      ],
+      children: appRoutes,
     },
   ],
   {

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig(({ mode }) => {
       rolldownOptions: {
         output: {
           manualChunks: (id) => {
+            if (id.includes('@heroicons/react/')) {
+              return 'icons'
+            }
             if (
               id.includes('node_modules/react/') ||
               id.includes('node_modules/react-dom/') ||


### PR DESCRIPTION
## Summary
- lazy-load non-shell UI routes and add route prefetching from a single router source of truth
- lazy-load Monaco-backed editors and modal content behind shared lazy boundaries
- preserve modal-shell behavior during lazy modal loads and apply low-risk image loading improvements

## Details
- adds shared `LazyBoundary`, `LazyModalBoundary`, and `LazyMonacoEditor` components
- refactors `router.tsx` to centralize lazy route definitions and retry-safe preloading
- wires route prefetching into nav, tabs, and collection detail tab navigation
- lazy-loads optional Monaco and markdown-heavy UI paths
- removes redundant overview exclusion fetches from `MediaCard`
- adds native `loading="lazy"` and `decoding="async"` hints for poster/backdrop images
