### PR TITLE
fix(ui): make overview title sort explicit

### DIFF
--- a/apps/ui/src/components/Common/MediaLibrarySortControl.tsx
+++ b/apps/ui/src/components/Common/MediaLibrarySortControl.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react'
 import { Select } from '../Forms/Select'
 
 const defaultSortValue = ''
+const defaultOverviewSortValue: MediaLibrarySortKey = 'title.asc'
 const titleAscendingSortLabel = 'Title (A-Z) Ascending'
 
 type SortParams = {
@@ -103,12 +104,12 @@ export const getMediaLibrarySortConfig = (
   libraryType?: MediaLibrary['type'],
 ): SortConfig<MediaLibrarySortParams> => {
   return {
-    defaultValue: defaultSortValue,
+    defaultValue: defaultOverviewSortValue,
     options: [
-      {
-        value: defaultSortValue,
-        label: titleAscendingSortLabel,
-      },
+      createMediaLibrarySortOption(
+        defaultOverviewSortValue,
+        titleAscendingSortLabel,
+      ),
       ...getMediaLibrarySortOptions(libraryType, {
         includeTitleAscending: false,
       }),
@@ -143,7 +144,7 @@ export const getCollectionMediaSortConfig = (
   libraryType?: MediaLibrary['type'],
   includeDeleteSoonest: boolean = false,
 ): SortConfig<CollectionMediaSortParams> => {
-  const baseOptions = getCollectionSortConfig(
+  const options = getCollectionSortConfig(
     libraryType,
     includeDeleteSoonest ? 'Delete Latest' : 'Recently Added',
   ).options.map((option) => ({
@@ -157,20 +158,13 @@ export const getCollectionMediaSortConfig = (
       : undefined,
   }))
 
-  const [defaultOption, titleAscendingOption, ...remainingOptions] = baseOptions
+  if (includeDeleteSoonest) {
+    options.push(collectionDeleteSoonestSortOption)
+  }
 
   return {
     defaultValue: defaultSortValue,
-    options: includeDeleteSoonest
-      ? defaultOption && titleAscendingOption
-        ? [
-            defaultOption,
-            titleAscendingOption,
-            ...remainingOptions,
-            collectionDeleteSoonestSortOption,
-          ]
-        : baseOptions
-      : baseOptions,
+    options,
   }
 }
 

--- a/apps/ui/src/components/Overview/index.spec.tsx
+++ b/apps/ui/src/components/Overview/index.spec.tsx
@@ -1,6 +1,12 @@
 import type { MediaLibrary } from '@maintainerr/contracts'
-import { render, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useMediaServerLibraries } from '../../api/media-server'
 import { SearchContextProvider } from '../../contexts/search-context'
 import GetApiHandler from '../../utils/ApiHandler'
@@ -56,11 +62,19 @@ describe('Overview', () => {
     })
   })
 
+  afterEach(() => {
+    cleanup()
+  })
+
   it('shows title ascending as the default overview option', () => {
     const sortConfig = getMediaLibrarySortConfig('show')
 
     expect(sortConfig.options[0]?.label).toBe('Title (A-Z) Ascending')
-    expect(sortConfig.options[0]?.sortParams).toBeUndefined()
+    expect(sortConfig.options[0]?.value).toBe('title.asc')
+    expect(sortConfig.options[0]?.sortParams).toEqual({
+      sort: 'title',
+      sortOrder: 'asc',
+    })
   })
 
   it('only exposes the reachable delete soonest collection sort option', () => {
@@ -79,7 +93,7 @@ describe('Overview', () => {
     })
   })
 
-  it('omits sort params until a sort option is selected', () => {
+  it('keeps the selected library type in the query even without explicit sort params', () => {
     const url = new URL(
       `/media-server/library/shows-library/content?${buildLibraryContentQuery({
         page: 1,
@@ -89,7 +103,7 @@ describe('Overview', () => {
       'http://localhost',
     )
 
-    expect(url.searchParams.get('type')).toBeNull()
+    expect(url.searchParams.get('type')).toBe('show')
     expect(url.searchParams.get('sort')).toBeNull()
     expect(url.searchParams.get('sortOrder')).toBeNull()
   })
@@ -146,5 +160,49 @@ describe('Overview', () => {
     await waitFor(() => {
       expect(getApiHandlerMock).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('refetches overview content with explicit title ascending params when switching back', async () => {
+    libraries = [
+      {
+        id: 'shows-library',
+        title: 'Shows',
+        type: 'show',
+      } as MediaLibrary,
+    ]
+
+    render(
+      <SearchContextProvider>
+        <Overview />
+      </SearchContextProvider>,
+    )
+
+    await waitFor(() => {
+      expect(getApiHandlerMock).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.change(screen.getByLabelText('Sort overview items'), {
+      target: { value: 'title.desc' },
+    })
+
+    await waitFor(() => {
+      expect(getApiHandlerMock).toHaveBeenCalledTimes(2)
+    })
+
+    expect(getApiHandlerMock.mock.calls[1]?.[0]).toContain(
+      'sort=title&sortOrder=desc',
+    )
+
+    fireEvent.change(screen.getByLabelText('Sort overview items'), {
+      target: { value: 'title.asc' },
+    })
+
+    await waitFor(() => {
+      expect(getApiHandlerMock).toHaveBeenCalledTimes(3)
+    })
+
+    expect(getApiHandlerMock.mock.calls[2]?.[0]).toContain(
+      'sort=title&sortOrder=asc',
+    )
   })
 })

--- a/apps/ui/src/components/Overview/index.tsx
+++ b/apps/ui/src/components/Overview/index.tsx
@@ -38,7 +38,7 @@ export const buildLibraryContentQuery = ({
   return new URLSearchParams({
     page: `${page}`,
     limit: `${limit}`,
-    ...(libraryType && sortParams ? { type: libraryType } : {}),
+    ...(libraryType ? { type: libraryType } : {}),
     ...(sortParams ?? {}),
   })
 }


### PR DESCRIPTION
## Summary
- make the Overview default sort an explicit `title.asc` option instead of an empty fallback
- preserve the selected library type in Overview content queries even when no explicit sort params are present
- add regression coverage for switching away from and back to Title (A-Z) Ascending

Tested and works.