### PR TITLE
fix(metadata): validate direct provider IDs by year with cross-provider fallback

### DIFF
--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -402,6 +402,31 @@ describe('MetadataService', () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  it('warns when the provider has no release year but still accepts the ids', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-provider-missing-year',
+      type: 'movie',
+      year: 2099,
+      title: 'Fixture Orbit',
+      providerIds: { tmdb: ['808001'], imdb: [], tvdb: [] },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Fixture Orbit',
+        year: undefined,
+        type: 'movie',
+        externalIds: { tmdb: 808001, type: 'movie' },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tmdb: 808001, type: 'movie' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('TMDB returned no release year'),
+    );
+  });
+
   it('accepts direct provider ids when a parenthesized year in the title matches the provider year', async () => {
     const libraryItem = createMediaItem({
       id: 'show-1',

--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -481,7 +481,7 @@ describe('MetadataService', () => {
     const { service, logger } = createService({
       tmdbDetails: {
         title: 'Fixture Runners',
-        year: 2098,
+        year: 2096,
         type: 'movie',
         externalIds: { tmdb: 777001, type: 'movie' },
       },
@@ -510,13 +510,13 @@ describe('MetadataService', () => {
     const { service, logger } = createService({
       tmdbDetails: {
         title: 'Fixture Runners',
-        year: 2098,
+        year: 2096,
         type: 'movie',
         externalIds: { tmdb: 777002, type: 'movie' },
       },
       tvdbDetails: {
         title: 'Fixture Runners',
-        year: 2098,
+        year: 2096,
         type: 'movie',
         externalIds: { tvdb: 888002, type: 'movie' },
       },
@@ -526,10 +526,10 @@ describe('MetadataService', () => {
 
     expect(result).toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('TMDB returned 2098'),
+      expect.stringContaining('TMDB returned 2096'),
     );
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('TVDB returned 2098'),
+      expect.stringContaining('TVDB returned 2096'),
     );
   });
 
@@ -602,7 +602,7 @@ describe('MetadataService', () => {
     const { service, logger } = createService({
       tmdbDetails: {
         title: 'Fixture Beacon',
-        year: 2098,
+        year: 2096,
         type: 'movie',
         externalIds: { tmdb: 333, type: 'movie' },
       },
@@ -619,5 +619,60 @@ describe('MetadataService', () => {
 
     expect(result).toMatchObject({ tvdb: 555, type: 'movie' });
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  // ±1 year tolerance: festival premiere vs theatrical release and similar
+  // regional drift routinely produce a single-year gap between the media
+  // server and TMDB/TVDB. Single-year gaps are accepted; larger gaps are
+  // still rejected.
+  it('accepts direct ids with a logged note when the provider year differs by exactly one year', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-year-tolerance',
+      type: 'movie',
+      year: 2099,
+      title: 'Fixture Premiere',
+      providerIds: { tmdb: ['606001'], imdb: [], tvdb: [] },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Fixture Premiere',
+        year: 2098,
+        type: 'movie',
+        externalIds: { tmdb: 606001, type: 'movie' },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tmdb: 606001, type: 'movie' });
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('one-year drift'),
+    );
+  });
+
+  it('rejects direct ids when the provider year differs by more than one year', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-year-outside-tolerance',
+      type: 'movie',
+      year: 2099,
+      title: 'Fixture Premiere',
+      providerIds: { tmdb: ['606002'], imdb: [], tvdb: [] },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Fixture Premiere',
+        year: 2097,
+        type: 'movie',
+        externalIds: { tmdb: 606002, type: 'movie' },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('TMDB returned 2097'),
+    );
   });
 });

--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -302,34 +302,85 @@ describe('MetadataService', () => {
     });
   });
 
-  it('accepts direct provider ids without fetching details when the title suffix already provides the matching year', async () => {
+  it('accepts direct provider ids when titles differ but release years agree', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-1',
+      type: 'movie',
+      year: 2025,
+      title: 'The Fixture Quartet: Prologue',
+      providerIds: {
+        tmdb: ['900001'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const { service, logger, mediaServer } = createService({
+      tmdbDetails: {
+        title: 'The Fixture 4: Prologue',
+        year: 2025,
+        type: 'movie',
+        externalIds: {
+          tmdb: 900001,
+          type: 'movie',
+        },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(mediaServer.getMetadata).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      tmdb: 900001,
+      type: 'movie',
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('rejects direct provider ids when no configured provider confirms the release year', async () => {
+    const libraryItem = createMediaItem({
+      id: 'show-1',
+      type: 'show',
+      year: 2025,
+      title: 'Fixture Chronicle',
+      providerIds: {
+        tmdb: ['771'],
+        imdb: [],
+        tvdb: [],
+      },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Unrelated Series',
+        year: 2014,
+        type: 'tv',
+        externalIds: {
+          tmdb: 771,
+          type: 'tv',
+        },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Rejected direct provider IDs for media server item "Fixture Chronicle" (2025) because no configured metadata provider confirmed the release year. Disagreements: TMDB returned 2014. The media server likely has incorrect metadata for this item, so no external IDs will be returned from this resolution attempt.',
+    );
+  });
+
+  it('accepts direct provider ids when the media server item has no year signal to reject with', async () => {
     const libraryItem = createMediaItem({
       id: 'show-1',
       type: 'show',
       year: undefined,
-      title: 'Fixture Chronicle (2025)',
+      title: 'Fixture Localized',
       providerIds: {
         tmdb: ['771'],
         imdb: [],
         tvdb: [],
       },
     });
-    const detailItem = createMediaItem({
-      id: 'show-1',
-      type: 'show',
-      year: 2025,
-      title: 'Fixture Chronicle (2025)',
-      providerIds: {
-        tmdb: ['771'],
-        imdb: [],
-        tvdb: [],
-      },
-    });
-    const mediaServer = {
-      getMetadata: jest.fn().mockResolvedValue(detailItem),
-    };
-    const { service, logger } = createService({
-      mediaServer,
+    const { service, logger, mediaServer } = createService({
       tmdbDetails: {
         title: 'Fixture Chronicle',
         year: 2025,
@@ -349,112 +400,9 @@ describe('MetadataService', () => {
       type: 'tv',
     });
     expect(logger.warn).not.toHaveBeenCalled();
-    expect(logger.debug).toHaveBeenCalledWith(
-      'Title mismatch resolved by year-aware match for media server item "Fixture Chronicle (2025)" against "Fixture Chronicle".',
-    );
   });
 
-  it('still rejects direct provider ids after fetching details when the title suffix year disagrees', async () => {
-    const libraryItem = createMediaItem({
-      id: 'show-1',
-      type: 'show',
-      year: undefined,
-      title: 'Fixture Chronicle (2025)',
-      providerIds: {
-        tmdb: ['771'],
-        imdb: [],
-        tvdb: [],
-      },
-    });
-    const detailItem = createMediaItem({
-      id: 'show-1',
-      type: 'show',
-      year: 2025,
-      title: 'Fixture Chronicle (2025)',
-      providerIds: {
-        tmdb: ['771'],
-        imdb: [],
-        tvdb: [],
-      },
-    });
-    const mediaServer = {
-      getMetadata: jest.fn().mockResolvedValue(detailItem),
-    };
-    const { service, logger } = createService({
-      mediaServer,
-      tmdbDetails: {
-        title: 'Fixture Chronicle',
-        year: 2024,
-        type: 'tv',
-        externalIds: {
-          tmdb: 771,
-          type: 'tv',
-        },
-      },
-    });
-
-    const result = await service.resolveIdsFromMediaItem(libraryItem);
-
-    expect(mediaServer.getMetadata).toHaveBeenCalledWith('show-1');
-    expect(result).toBeUndefined();
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Rejected direct provider IDs for media server item "Fixture Chronicle (2025)" because they resolved to "Fixture Chronicle" instead. The media server likely has incorrect metadata for this item, so no external IDs will be returned from this resolution attempt.',
-    );
-  });
-
-  it('fetches detail metadata when the initial item lacks a usable year signal', async () => {
-    const libraryItem = createMediaItem({
-      id: 'show-1',
-      type: 'show',
-      year: undefined,
-      title: 'Fixture Localized',
-      providerIds: {
-        tmdb: ['771'],
-        imdb: [],
-        tvdb: [],
-      },
-    });
-    const detailItem = createMediaItem({
-      id: 'show-1',
-      type: 'show',
-      year: 2025,
-      title: 'Fixture Chronicle (2025)',
-      providerIds: {
-        tmdb: ['771'],
-        imdb: [],
-        tvdb: [],
-      },
-    });
-    const mediaServer = {
-      getMetadata: jest.fn().mockResolvedValue(detailItem),
-    };
-    const { service, logger } = createService({
-      mediaServer,
-      tmdbDetails: {
-        title: 'Fixture Chronicle',
-        year: 2025,
-        type: 'tv',
-        externalIds: {
-          tmdb: 771,
-          type: 'tv',
-        },
-      },
-    });
-
-    const result = await service.resolveIdsFromMediaItem(libraryItem);
-
-    expect(mediaServer.getMetadata).toHaveBeenCalledWith('show-1');
-    expect(result).toMatchObject({
-      tmdb: 771,
-      type: 'tv',
-    });
-    expect(logger.warn).not.toHaveBeenCalled();
-    expect(logger.debug).toHaveBeenCalledWith(
-      'Title mismatch resolved by year-aware match for media server item "Fixture Localized" against "Fixture Chronicle".',
-    );
-  });
-
-  it('skips the detail lookup when the initial item already passes the year-aware title check', async () => {
+  it('accepts direct provider ids when a parenthesized year in the title matches the provider year', async () => {
     const libraryItem = createMediaItem({
       id: 'show-1',
       type: 'show',
@@ -517,5 +465,159 @@ describe('MetadataService', () => {
       tmdb: 771,
       type: 'tv',
     });
+  });
+
+  // Cross-provider fallback: when the primary provider disagrees with the
+  // media server year, the next configured provider gets a chance to vouch
+  // for the ID before we reject.
+  it('accepts direct ids via the secondary provider when the primary disagrees on year', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-fallback-1',
+      type: 'movie',
+      year: 2099,
+      title: 'Fixture Runners',
+      providerIds: { tmdb: ['777001'], imdb: [], tvdb: ['888001'] },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Fixture Runners',
+        year: 2098,
+        type: 'movie',
+        externalIds: { tmdb: 777001, type: 'movie' },
+      },
+      tvdbDetails: {
+        title: 'Fixture Runners',
+        year: 2099,
+        type: 'movie',
+        externalIds: { tvdb: 888001, type: 'movie' },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tvdb: 888001, type: 'movie' });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('rejects direct ids when every configured provider disagrees on year', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-fallback-2',
+      type: 'movie',
+      year: 2099,
+      title: 'Fixture Runners',
+      providerIds: { tmdb: ['777002'], imdb: [], tvdb: ['888002'] },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Fixture Runners',
+        year: 2098,
+        type: 'movie',
+        externalIds: { tmdb: 777002, type: 'movie' },
+      },
+      tvdbDetails: {
+        title: 'Fixture Runners',
+        year: 2098,
+        type: 'movie',
+        externalIds: { tvdb: 888002, type: 'movie' },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('TMDB returned 2098'),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('TVDB returned 2098'),
+    );
+  });
+
+  // Re-scan mixup: a newer library item wrongly tagged with an older entry's
+  // id. Titles are literally identical — only the year distinguishes them.
+  // This is the case a title-first policy would silently accept.
+  it('rejects a rescan id mixup where titles match exactly but years differ', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-rescan-mixup',
+      type: 'movie',
+      year: 2099,
+      title: 'Fixture Road',
+      providerIds: { tmdb: ['444111'], imdb: [], tvdb: [] },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Fixture Road',
+        year: 2091,
+        type: 'movie',
+        externalIds: { tmdb: 444111, type: 'movie' },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('(2099)'));
+  });
+
+  // Stale direct IDs must still be corrected to the provider's canonical
+  // ID when the provider's returned externalIds expose a different value
+  // for that same provider (e.g. a merged/redirected TMDB entry).
+  it('corrects a stale direct id when the provider returns a different canonical id', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-stale-id',
+      type: 'movie',
+      year: 2099,
+      title: 'Fixture Harbor',
+      providerIds: { tmdb: ['111'], imdb: [], tvdb: [] },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Fixture Harbor',
+        year: 2099,
+        type: 'movie',
+        externalIds: { tmdb: 222, type: 'movie' },
+      },
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tmdb: 222, type: 'movie' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Corrected TMDB ID: 111 to 222'),
+    );
+  });
+
+  // Second-opinion path: the media item exposes only TMDB + IMDB tags.
+  // TMDB disagrees on year. TVDB has no direct id on the item but can be
+  // reached via the IMDB id, and when consulted it vouches for the year.
+  // The validation flow should bridge IMDB -> TVDB, then accept.
+  it('bridges to a secondary provider via imdb when the primary disagrees on year', async () => {
+    const libraryItem = createMediaItem({
+      id: 'movie-bridge-1',
+      type: 'movie',
+      year: 2099,
+      title: 'Fixture Beacon',
+      providerIds: { tmdb: ['333'], imdb: ['tt0099785'], tvdb: [] },
+    });
+    const { service, logger } = createService({
+      tmdbDetails: {
+        title: 'Fixture Beacon',
+        year: 2098,
+        type: 'movie',
+        externalIds: { tmdb: 333, type: 'movie' },
+      },
+      tvdbDetails: {
+        title: 'Fixture Beacon',
+        year: 2099,
+        type: 'movie',
+        externalIds: { tvdb: 555, type: 'movie' },
+      },
+      tvdbMovieId: 555,
+    });
+
+    const result = await service.resolveIdsFromMediaItem(libraryItem);
+
+    expect(result).toMatchObject({ tvdb: 555, type: 'movie' });
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/modules/metadata/metadata.service.spec.ts
+++ b/apps/server/src/modules/metadata/metadata.service.spec.ts
@@ -583,7 +583,9 @@ describe('MetadataService', () => {
 
     expect(result).toMatchObject({ tmdb: 222, type: 'movie' });
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Corrected TMDB ID: 111 to 222'),
+      expect.stringContaining(
+        'Corrected TMDB ID for "Fixture Harbor": 111 to 222',
+      ),
     );
   });
 

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -523,6 +523,7 @@ export class MetadataService {
     ids: ProviderIds,
     externalIds: ProviderIds,
     sourceProviderName: string,
+    itemTitle?: string,
   ): void {
     for (const provider of this.providers) {
       const currentId = provider.extractId(ids);
@@ -536,8 +537,9 @@ export class MetadataService {
         continue;
       }
 
+      const target = itemTitle ? ` for "${itemTitle}"` : '';
       this.logger.warn(
-        `Corrected ${provider.name} ID: ${currentId} to ${correctId} via ${sourceProviderName} cross-reference. The media server may have incorrect metadata for this item.`,
+        `Corrected ${provider.name} ID${target}: ${currentId} to ${correctId} via ${sourceProviderName} cross-reference. The media server may have incorrect metadata for this item.`,
       );
       provider.assignId(ids, correctId);
     }
@@ -763,46 +765,57 @@ export class MetadataService {
       if (id === undefined) return undefined;
       consulted.add(provider);
 
-      const details = await provider.getDetails(id, ids.type);
-      if (!details) return undefined;
+      const providerDetails = await provider.getDetails(id, ids.type);
+      if (!providerDetails) return undefined;
 
-      if (details.externalIds) {
-        this.applyIdCorrections(ids, details.externalIds, provider.name);
-        this.fillMissingIds(ids, details.externalIds);
+      if (providerDetails.externalIds) {
+        this.applyIdCorrections(
+          ids,
+          providerDetails.externalIds,
+          provider.name,
+          item.title,
+        );
+        this.fillMissingIds(ids, providerDetails.externalIds);
       }
 
-      // No year on either side: nothing to check against.
-      if (itemYear === undefined || details.year === undefined) {
-        return details;
+      // Missing year on either side: nothing to sanity-check against, so we
+      // trust the ID. Logged so ambiguous accepts are still visible.
+      if (itemYear === undefined || providerDetails.year === undefined) {
+        const missingSide =
+          itemYear === undefined ? 'media server' : provider.name;
+        this.logger.debug(
+          `Accepted direct provider IDs for "${item.title}" via ${provider.name} without a year check (${missingSide} year was undefined).`,
+        );
+        return providerDetails;
       }
 
-      const delta = Math.abs(itemYear - details.year);
+      const delta = Math.abs(itemYear - providerDetails.year);
 
       if (delta === 0) {
         if (disagreements.length > 0) {
           this.logger.debug(
-            `Direct provider IDs for "${item.title}" validated by ${provider.name} (${details.year}) after year disagreement from: ${disagreements.join(', ')}.`,
+            `Direct provider IDs for "${item.title}" validated by ${provider.name} (${providerDetails.year}) after year disagreement from: ${disagreements.join(', ')}.`,
           );
         }
-        return details;
+        return providerDetails;
       }
 
       // ±1 tolerance covers festival/theatrical release drift.
       if (delta === 1) {
         this.logger.debug(
-          `Accepted direct provider IDs for "${item.title}" (${itemYear}) with a one-year drift from ${provider.name} (${details.year}).`,
+          `Accepted direct provider IDs for "${item.title}" (${itemYear}) with a one-year drift from ${provider.name} (${providerDetails.year}).`,
         );
-        return details;
+        return providerDetails;
       }
 
-      disagreements.push(`${provider.name} returned ${details.year}`);
+      disagreements.push(`${provider.name} returned ${providerDetails.year}`);
       return undefined;
     };
 
     // First pass: consult every provider that already has an ID on the item.
     for (const provider of this.getOrderedProviders()) {
-      const details = await evaluate(provider);
-      if (details) return details;
+      const providerDetails = await evaluate(provider);
+      if (providerDetails) return providerDetails;
     }
 
     // Second pass: if all direct provider IDs disagreed on year, bridge from
@@ -811,8 +824,8 @@ export class MetadataService {
     if (disagreements.length > 0) {
       await this.bridgeMissingProviderIds(ids);
       for (const provider of this.getOrderedProviders()) {
-        const details = await evaluate(provider);
-        if (details) return details;
+        const providerDetails = await evaluate(provider);
+        if (providerDetails) return providerDetails;
       }
     }
 
@@ -836,7 +849,7 @@ export class MetadataService {
           continue;
         }
         const results = await provider.findByExternalId(value, key);
-        if (!results?.length) {
+        if (!results) {
           continue;
         }
         for (const result of results) {

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -778,13 +778,20 @@ export class MetadataService {
         this.fillMissingIds(ids, providerDetails.externalIds);
       }
 
-      // Missing year on either side: nothing to sanity-check against, so we
-      // trust the ID. Logged so ambiguous accepts are still visible.
-      if (itemYear === undefined || providerDetails.year === undefined) {
-        const missingSide =
-          itemYear === undefined ? 'media server' : provider.name;
+      // Missing year on either side: nothing to sanity-check against. We
+      // trust the ID, but log so ambiguous accepts stay visible. Provider
+      // missing year is the suspicious case (TMDB/TVDB almost always have
+      // one) so it's logged at warn; media server missing year is common
+      // in untagged libraries and stays at debug.
+      if (providerDetails.year === undefined) {
+        this.logger.warn(
+          `Accepted direct provider IDs for "${item.title}" via ${provider.name} without a year check — ${provider.name} returned no release year for this entry.`,
+        );
+        return providerDetails;
+      }
+      if (itemYear === undefined) {
         this.logger.debug(
-          `Accepted direct provider IDs for "${item.title}" via ${provider.name} without a year check (${missingSide} year was undefined).`,
+          `Accepted direct provider IDs for "${item.title}" via ${provider.name} without a year check — media server item has no year.`,
         );
         return providerDetails;
       }

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -321,20 +321,13 @@ export class MetadataService {
       let metadataDetails: MetadataDetails | undefined;
 
       if (hasAvailableDirectIds) {
-        metadataDetails = await this.getDetails(ids, ids.type);
+        metadataDetails = await this.validateDirectIds(item, ids);
 
-        if (
-          item.title &&
-          metadataDetails?.title &&
-          !(await this.matchesProviderDetails(item, metadataDetails))
-        ) {
-          this.logger.warn(
-            `Rejected direct provider IDs for media server item "${item.title}" because they resolved to "${metadataDetails.title}" instead. The media server likely has incorrect metadata for this item, so no external IDs will be returned from this resolution attempt.`,
-          );
+        if (!metadataDetails) {
           return undefined;
         }
 
-        if (metadataDetails?.externalIds) {
+        if (metadataDetails.externalIds) {
           this.fillMissingIds(ids, metadataDetails.externalIds);
         }
       }
@@ -515,11 +508,22 @@ export class MetadataService {
       return undefined;
     }
 
-    const externalIds = providerResult.result.externalIds;
-    if (!externalIds) {
-      return providerResult.result;
+    if (providerResult.result.externalIds) {
+      this.applyIdCorrections(
+        ids,
+        providerResult.result.externalIds,
+        providerResult.provider,
+      );
     }
 
+    return providerResult.result;
+  }
+
+  private applyIdCorrections(
+    ids: ProviderIds,
+    externalIds: ProviderIds,
+    sourceProviderName: string,
+  ): void {
     for (const provider of this.providers) {
       const currentId = provider.extractId(ids);
       const correctId = provider.extractId(externalIds);
@@ -533,12 +537,10 @@ export class MetadataService {
       }
 
       this.logger.warn(
-        `Corrected ${provider.name} ID: ${currentId} to ${correctId} via ${providerResult.provider} cross-reference. The media server may have incorrect metadata for this item.`,
+        `Corrected ${provider.name} ID: ${currentId} to ${correctId} via ${sourceProviderName} cross-reference. The media server may have incorrect metadata for this item.`,
       );
       provider.assignId(ids, correctId);
     }
-
-    return providerResult.result;
   }
 
   async getPersonDetails(ids: ProviderIds): Promise<PersonDetails | undefined> {
@@ -663,31 +665,6 @@ export class MetadataService {
     return ids;
   }
 
-  private titlesMatch(left: string, right: string): boolean {
-    const normalizedLeft = this.normalizeTitle(left);
-    const normalizedRight = this.normalizeTitle(right);
-
-    if (normalizedLeft.length === 0 || normalizedRight.length === 0) {
-      return left.trim().toLowerCase() === right.trim().toLowerCase();
-    }
-
-    return normalizedLeft === normalizedRight;
-  }
-
-  private normalizeTitle(value: string): string {
-    let normalized = '';
-
-    for (const character of value.toLowerCase()) {
-      const isDigit = character >= '0' && character <= '9';
-      const isLetter = character >= 'a' && character <= 'z';
-      if (isDigit || isLetter) {
-        normalized += character;
-      }
-    }
-
-    return normalized;
-  }
-
   private readTitleYear(title: string): number | undefined {
     const trimmedTitle = title.trim();
     const parenthesizedSuffixStart = trimmedTitle.length - 6;
@@ -746,96 +723,120 @@ export class MetadataService {
     return this.readTitleYear(item.title);
   }
 
-  private stripTitleYear(title: string, year: number): string {
-    const trimmedTitle = title.trim();
-    const parenthesizedSuffix = `(${year})`;
-
-    if (trimmedTitle.endsWith(parenthesizedSuffix)) {
-      return trimmedTitle
-        .slice(0, trimmedTitle.length - parenthesizedSuffix.length)
-        .trimEnd();
-    }
-
-    const spaceSeparatedSuffix = ` ${year}`;
-    if (trimmedTitle.endsWith(spaceSeparatedSuffix)) {
-      return trimmedTitle
-        .slice(0, trimmedTitle.length - spaceSeparatedSuffix.length)
-        .trimEnd();
-    }
-
-    return trimmedTitle;
-  }
-
-  private matchesTitleWithYear(
-    item: Pick<MediaItem, 'title' | 'year' | 'originallyAvailableAt'>,
-    metadataDetails: MetadataDetails,
-  ): boolean {
-    const itemYear = this.readItemYear(item);
-    if (
-      itemYear === undefined ||
-      metadataDetails.year === undefined ||
-      itemYear !== metadataDetails.year
-    ) {
-      return false;
-    }
-
-    const metadataTitle = this.stripTitleYear(
-      metadataDetails.title,
-      metadataDetails.year,
-    );
-
-    return this.titlesMatch(
-      this.stripTitleYear(item.title, itemYear),
-      metadataTitle,
-    );
-  }
-
-  private async loadItemDetails(
-    itemId: string,
-  ): Promise<MediaItem | undefined> {
-    try {
-      const mediaServer = await this.mediaServerFactory.getService();
-      return await mediaServer.getMetadata(itemId);
-    } catch (error) {
-      this.logger.debug(error);
-      return undefined;
-    }
-  }
-
-  private logYearMatch(itemTitle: string, providerTitle: string): void {
-    this.logger.debug(
-      `Title mismatch resolved by year-aware match for media server item "${itemTitle}" against "${providerTitle}".`,
-    );
-  }
-
-  private async matchesProviderDetails(
+  /**
+   * Validate direct provider IDs from the media server by walking the
+   * configured providers in preference order. Each provider is asked for
+   * details about whatever direct ID it can extract from the item, and
+   * the first provider whose release year matches the media server's year
+   * "vouches" for the ID set — we return its details and use its external
+   * IDs to fill in the other provider slots.
+   *
+   * This is the ID-primary / year-sanity model:
+   *   - The ID is the decisive signal. A successful lookup means the ID
+   *     points at a real entry in the authoritative provider for that type.
+   *   - The release year is the only sanity check. Titles are deliberately
+   *     not compared, because cosmetic title drift (localization, numeral
+   *     form, edition suffixes) is normal and comparing them caused the
+   *     regressions in #2636 / #2638.
+   *   - Cross-provider fallback gives the library a second opinion when
+   *     the preferred provider disagrees with the media server on year —
+   *     the scenario the metadata settings description already promises
+   *     users when they configure TVDB alongside TMDB.
+   *
+   * Rejection is the fail-closed default when no provider agrees on the
+   * year. If the media server has no year signal at all, the first
+   * successful provider lookup is trusted (we have nothing to reject with).
+   */
+  private async validateDirectIds(
     item: MediaItem,
-    metadataDetails: MetadataDetails,
-  ): Promise<boolean> {
-    if (this.titlesMatch(item.title, metadataDetails.title)) {
-      return true;
+    ids: ResolvedMediaIds,
+  ): Promise<MetadataDetails | undefined> {
+    const itemYear = this.readItemYear(item);
+    const disagreements: string[] = [];
+    const consulted = new Set<IMetadataProvider>();
+
+    const evaluate = async (
+      provider: IMetadataProvider,
+    ): Promise<MetadataDetails | undefined> => {
+      if (consulted.has(provider)) return undefined;
+      const id = provider.extractId(ids);
+      if (id === undefined) return undefined;
+      consulted.add(provider);
+
+      const details = await provider.getDetails(id, ids.type);
+      if (!details) return undefined;
+
+      if (details.externalIds) {
+        this.applyIdCorrections(ids, details.externalIds, provider.name);
+        this.fillMissingIds(ids, details.externalIds);
+      }
+
+      const accept =
+        itemYear === undefined ||
+        details.year === undefined ||
+        itemYear === details.year;
+
+      if (accept) {
+        if (disagreements.length > 0) {
+          this.logger.debug(
+            `Direct provider IDs for "${item.title}" validated by ${provider.name} (${details.year}) after year disagreement from: ${disagreements.join(', ')}.`,
+          );
+        }
+        return details;
+      }
+
+      disagreements.push(`${provider.name} returned ${details.year}`);
+      return undefined;
+    };
+
+    // First pass: consult every provider that already has an ID on the item.
+    for (const provider of this.getOrderedProviders()) {
+      const details = await evaluate(provider);
+      if (details) return details;
     }
 
-    if (this.matchesTitleWithYear(item, metadataDetails)) {
-      this.logYearMatch(item.title, metadataDetails.title);
-      return true;
+    // Second pass: if all direct provider IDs disagreed on year, bridge from
+    // non-provider external references (for example IMDB) so a configured
+    // provider that was not on the item can still vouch.
+    if (disagreements.length > 0) {
+      await this.bridgeMissingProviderIds(ids);
+      for (const provider of this.getOrderedProviders()) {
+        const details = await evaluate(provider);
+        if (details) return details;
+      }
     }
 
-    const detailItem = await this.loadItemDetails(item.id);
-    if (!detailItem) {
-      return false;
+    if (disagreements.length > 0) {
+      this.logger.warn(
+        `Rejected direct provider IDs for media server item "${item.title}" (${itemYear}) because no configured metadata provider confirmed the release year. Disagreements: ${disagreements.join('; ')}. The media server likely has incorrect metadata for this item, so no external IDs will be returned from this resolution attempt.`,
+      );
     }
 
-    if (this.titlesMatch(detailItem.title, metadataDetails.title)) {
-      return true;
-    }
+    return undefined;
+  }
 
-    if (this.matchesTitleWithYear(detailItem, metadataDetails)) {
-      this.logYearMatch(item.title, metadataDetails.title);
-      return true;
+  private async bridgeMissingProviderIds(ids: ResolvedMediaIds): Promise<void> {
+    const availableProviderKeys = new Set(this.getOrderedProviderKeys());
+    for (const [key, value] of Object.entries(ids)) {
+      if (!value || key === 'type' || availableProviderKeys.has(key)) {
+        continue;
+      }
+      for (const provider of this.getOrderedProviders()) {
+        if (provider.extractId(ids) !== undefined) {
+          continue;
+        }
+        const results = await provider.findByExternalId(value, key);
+        if (!results?.length) {
+          continue;
+        }
+        for (const result of results) {
+          const id = ids.type === 'movie' ? result.movieId : result.tvShowId;
+          if (id !== undefined) {
+            provider.assignId(ids, id);
+          }
+        }
+      }
     }
-
-    return false;
   }
 
   private async resolveAllIds(

--- a/apps/server/src/modules/metadata/metadata.service.ts
+++ b/apps/server/src/modules/metadata/metadata.service.ts
@@ -771,17 +771,27 @@ export class MetadataService {
         this.fillMissingIds(ids, details.externalIds);
       }
 
-      const accept =
-        itemYear === undefined ||
-        details.year === undefined ||
-        itemYear === details.year;
+      // No year on either side: nothing to check against.
+      if (itemYear === undefined || details.year === undefined) {
+        return details;
+      }
 
-      if (accept) {
+      const delta = Math.abs(itemYear - details.year);
+
+      if (delta === 0) {
         if (disagreements.length > 0) {
           this.logger.debug(
             `Direct provider IDs for "${item.title}" validated by ${provider.name} (${details.year}) after year disagreement from: ${disagreements.join(', ')}.`,
           );
         }
+        return details;
+      }
+
+      // ±1 tolerance covers festival/theatrical release drift.
+      if (delta === 1) {
+        this.logger.debug(
+          `Accepted direct provider IDs for "${item.title}" (${itemYear}) with a one-year drift from ${provider.name} (${details.year}).`,
+        );
         return details;
       }
 

--- a/apps/ui/src/components/Settings/Metadata/index.tsx
+++ b/apps/ui/src/components/Settings/Metadata/index.tsx
@@ -609,8 +609,9 @@ const MetadataSettings = () => {
             Configure metadata providers and set the primary source for posters,
             backdrops, and metadata enrichment. Adding a TVDB developer API key
             gives Maintainerr a fallback source for provider cross-references,
-            which helps recover missing IDs when TMDB alone cannot resolve a
-            match.
+            which helps recover missing IDs when the primary provider cannot
+            resolve a match and can provide a second opinion for some items
+            through existing external ID cross-references.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

Swaps the title-based check for direct provider IDs with an ID-first, year-as-sanity-check approach.

When an item has a direct TMDB/TVDB/IMDB id, the matching provider is asked for the entry's year. If it agrees with the media server, the id is accepted. If it disagrees, the next configured provider gets a chance to vouch — and if that secondary doesn't have an id on the item itself, Maintainerr bridges to it through an existing external reference (e.g. IMDB → TVDB). If nothing confirms the year, the direct ids are dropped so rules never run against the wrong entry.

Stale ids that a provider has since redirected (e.g. `tmdb: 111` → `222`) are still rewritten to the canonical value, same as before.

## Why

The old title check was too strict for normal libraries. Cosmetic drift — localization, Roman vs Arabic numerals, word-vs-digit, edition suffixes, punctuation — was enough to reject correct ids and silently drop items from rule evaluation.

Titles are also the wrong signal to lean on: they're too permissive when identical (re-scan mixups slip through) and too strict when they're not. Year is a much stronger discriminator — it's a single integer, immune to all the cosmetic drift, and genuine disagreement is a real red flag worth surfacing.

Fail-closed on unresolved year disagreement is the safer default for a deletion tool. Skipping a deletion is recoverable; deleting the wrong thing isn't.

**Known gap:** a wrong id that coincidentally shares the correct entry's year still slips through. Catching that would need an external title search the provider interface doesn't expose. Same as 3.3.0.

## Fixes

- Fixes #2636
- Fixes #2638