### PR TITLE
fix: refine *arr action and quality profile rule UI

### DIFF
--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.spec.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.spec.tsx
@@ -1,0 +1,82 @@
+import { ServarrAction } from '@maintainerr/contracts'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ArrAction from './index'
+
+const getApiHandlerMock = vi.fn()
+
+vi.mock('../../../../../utils/ApiHandler', () => ({
+  default: (...args: unknown[]) => getApiHandlerMock(...args),
+}))
+
+describe('ArrAction', () => {
+  beforeEach(() => {
+    getApiHandlerMock.mockReset()
+    getApiHandlerMock.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows fallback media server actions until a Sonarr server is selected', async () => {
+    render(
+      <ArrAction
+        type="Sonarr"
+        arrAction={ServarrAction.DELETE}
+        settingId={undefined}
+        onUpdate={vi.fn()}
+        options={[
+          { id: ServarrAction.DELETE, name: 'Delete entire show' },
+          { id: ServarrAction.DO_NOTHING, name: 'Do nothing' },
+          {
+            id: ServarrAction.CHANGE_QUALITY_PROFILE,
+            name: 'Change quality profile and search',
+          },
+        ]}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(getApiHandlerMock).toHaveBeenCalledWith('/settings/sonarr')
+    })
+
+    const actionSelect = screen.getByLabelText('Media server action')
+    const actionOptions = Array.from(
+      (actionSelect as HTMLSelectElement).options,
+    ).map((option) => option.text)
+
+    expect(actionOptions).toEqual(['Delete', 'Do nothing'])
+    expect(actionOptions).not.toContain('Change quality profile and search')
+  })
+
+  it('shows quality profile action after a Sonarr server is selected', async () => {
+    render(
+      <ArrAction
+        type="Sonarr"
+        arrAction={ServarrAction.DELETE}
+        settingId={12}
+        onUpdate={vi.fn()}
+        options={[
+          { id: ServarrAction.DELETE, name: 'Delete entire show' },
+          { id: ServarrAction.DO_NOTHING, name: 'Do nothing' },
+          {
+            id: ServarrAction.CHANGE_QUALITY_PROFILE,
+            name: 'Change quality profile and search',
+          },
+        ]}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(getApiHandlerMock).toHaveBeenCalledWith('/settings/sonarr')
+    })
+
+    const actionSelect = screen.getByLabelText('Sonarr action')
+    const actionOptions = Array.from(
+      (actionSelect as HTMLSelectElement).options,
+    ).map((option) => option.text)
+
+    expect(actionOptions).toContain('Change quality profile and search')
+  })
+})

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/ArrAction/index.tsx
@@ -1,3 +1,4 @@
+import { ServarrAction } from '@maintainerr/contracts'
 import { useEffect, useEffectEvent, useState } from 'react'
 import GetApiHandler from '../../../../../utils/ApiHandler'
 import { IRadarrSetting } from '../../../../Settings/Radarr'
@@ -22,8 +23,7 @@ interface Option {
 }
 
 const ArrAction = (props: ArrActionProps) => {
-  const selectedSetting =
-    props.settingId === undefined ? '-1' : (props.settingId?.toString() ?? '')
+  const selectedSetting = props.settingId?.toString() ?? ''
   const [settings, setSettings] = useState<(IRadarrSetting | ISonarrSetting)[]>(
     [],
   )
@@ -70,11 +70,11 @@ const ArrAction = (props: ArrActionProps) => {
   const options: Option[] = noneServerSelected
     ? [
         {
-          id: 0,
+          id: ServarrAction.DELETE,
           name: 'Delete',
         },
         {
-          id: 4,
+          id: ServarrAction.DO_NOTHING,
           name: 'Do nothing',
         },
       ]
@@ -98,9 +98,6 @@ const ArrAction = (props: ArrActionProps) => {
                 )
               }}
             >
-              {selectedSetting === '-1' && (
-                <option value="-1" disabled></option>
-              )}
               <option value="">None</option>
               {settings.map((e) => {
                 return (

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.spec.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.spec.tsx
@@ -1,8 +1,37 @@
-import { describe, expect, it } from 'vitest'
 import { ServarrAction } from '@maintainerr/contracts'
+import { describe, expect, it } from 'vitest'
 import { ruleGroupFormSchema } from './index'
 
 describe('ruleGroupFormSchema', () => {
+  it('allows missing arr server selection for fallback media server delete actions', () => {
+    const result = ruleGroupFormSchema.safeParse({
+      name: 'Rule group',
+      description: '',
+      libraryId: '1',
+      dataType: 'movie',
+      arrAction: ServarrAction.DELETE,
+      deleteAfterDays: 30,
+      keepLogsForMonths: 6,
+      tautulliWatchedPercentOverride: undefined,
+      showRecommended: true,
+      showHome: true,
+      listExclusions: true,
+      forceSeerr: false,
+      manualCollection: false,
+      manualCollectionName: '',
+      sortTitle: '',
+      active: true,
+      useRules: true,
+      radarrSettingsId: null,
+      sonarrSettingsId: undefined,
+      radarrQualityProfileId: undefined,
+      sonarrQualityProfileId: undefined,
+      ruleHandlerCronSchedule: null,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
   it('rejects null Radarr quality profile for CHANGE_QUALITY_PROFILE movie actions', () => {
     const result = ruleGroupFormSchema.safeParse({
       name: 'Rule group',

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -125,6 +125,102 @@ const numberOrUndefined = (value: unknown): number | undefined => {
   return value as number | undefined
 }
 
+const sortActionOptions = <T extends { name: string }>(options: T[]): T[] => {
+  return [...options].sort((left, right) => left.name.localeCompare(right.name))
+}
+
+const RADARR_ACTION_OPTIONS = sortActionOptions([
+  {
+    id: ServarrAction.DELETE,
+    name: 'Delete',
+  },
+  {
+    id: ServarrAction.UNMONITOR_DELETE_ALL,
+    name: 'Unmonitor and delete files',
+  },
+  {
+    id: ServarrAction.UNMONITOR,
+    name: 'Unmonitor and keep files',
+  },
+  {
+    id: ServarrAction.DO_NOTHING,
+    name: 'Do nothing',
+  },
+  {
+    id: ServarrAction.CHANGE_QUALITY_PROFILE,
+    name: 'Change quality profile and search',
+  },
+])
+
+const SONARR_SHOW_ACTION_OPTIONS = sortActionOptions([
+  {
+    id: ServarrAction.DELETE,
+    name: 'Delete entire show',
+  },
+  {
+    id: ServarrAction.UNMONITOR_DELETE_ALL,
+    name: 'Unmonitor show + seasons, delete all episodes',
+  },
+  {
+    id: ServarrAction.UNMONITOR_DELETE_EXISTING,
+    name: 'Unmonitor show, delete existing episodes',
+  },
+  {
+    id: ServarrAction.UNMONITOR,
+    name: 'Unmonitor show + seasons, keep files',
+  },
+  {
+    id: ServarrAction.DO_NOTHING,
+    name: 'Do nothing',
+  },
+  {
+    id: ServarrAction.CHANGE_QUALITY_PROFILE,
+    name: 'Change quality profile and search',
+  },
+])
+
+const SONARR_SEASON_ACTION_OPTIONS = sortActionOptions([
+  {
+    id: ServarrAction.DELETE,
+    name: 'Unmonitor and delete season',
+  },
+  {
+    id: ServarrAction.DELETE_SHOW_IF_EMPTY,
+    name: 'Unmonitor and delete season + delete show if empty',
+  },
+  {
+    id: ServarrAction.UNMONITOR_DELETE_EXISTING,
+    name: 'Unmonitor and delete existing episodes',
+  },
+  {
+    id: ServarrAction.UNMONITOR,
+    name: 'Unmonitor season and keep files',
+  },
+  {
+    id: ServarrAction.UNMONITOR_SHOW_IF_EMPTY,
+    name: 'Unmonitor season + unmonitor show if empty',
+  },
+  {
+    id: ServarrAction.DO_NOTHING,
+    name: 'Do nothing',
+  },
+])
+
+const SONARR_EPISODE_ACTION_OPTIONS = sortActionOptions([
+  {
+    id: ServarrAction.DELETE,
+    name: 'Unmonitor and delete episode',
+  },
+  {
+    id: ServarrAction.UNMONITOR,
+    name: 'Unmonitor and keep file',
+  },
+  {
+    id: ServarrAction.DO_NOTHING,
+    name: 'Do nothing',
+  },
+])
+
 export const ruleGroupFormSchema = z
   .object({
     name: z.string().trim().min(1, 'Name is required'),
@@ -197,23 +293,6 @@ export const ruleGroupFormSchema = z
       message: 'Custom collection name is required',
     },
   )
-  .superRefine((data, ctx) => {
-    if (
-      data.radarrSettingsId === undefined &&
-      data.sonarrSettingsId === undefined
-    ) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['radarrSettingsId'],
-        message: 'Select an *arr server',
-      })
-      ctx.addIssue({
-        code: 'custom',
-        path: ['sonarrSettingsId'],
-        message: 'Select an *arr server',
-      })
-    }
-  })
   .refine(
     (data) =>
       data.arrAction === undefined ||
@@ -354,6 +433,8 @@ const AddModal = (props: AddModal) => {
     control,
     name: 'sonarrQualityProfileId',
   }) as number | null | undefined
+  const hasSelectedRadarrServer = radarrSettingsId != null
+  const hasSelectedSonarrServer = sonarrSettingsId != null
   const [showCommunityModal, setShowCommunityModal] = useState(false)
   const [yamlImporterModal, setYamlImporterModal] = useState(false)
   const [configureNotificionModal, setConfigureNotificationModal] =
@@ -443,6 +524,14 @@ const AddModal = (props: AddModal) => {
     settingId?: number | null,
   ) => {
     updateArrOption(arrAction)
+
+    if (type === 'Radarr' && settingId !== radarrSettingsId) {
+      setValue('radarrQualityProfileId', undefined)
+    }
+
+    if (type === 'Sonarr' && settingId !== sonarrSettingsId) {
+      setValue('sonarrQualityProfileId', undefined)
+    }
 
     const newRadarrId = type === 'Radarr' ? settingId : undefined
     const newSonarrId = type === 'Sonarr' ? settingId : undefined
@@ -761,36 +850,19 @@ const AddModal = (props: AddModal) => {
                       arrAction={arrActionValue}
                       settingIdError={errors.radarrSettingsId?.message}
                       settingId={radarrSettingsId}
-                      onUpdate={(arrAction: number, settingId) => {
+                      onUpdate={(
+                        arrAction: number,
+                        settingId?: number | null,
+                      ) => {
                         handleUpdateArrAction('Radarr', arrAction, settingId)
                       }}
-                      options={[
-                        {
-                          id: ServarrAction.DELETE,
-                          name: 'Delete',
-                        },
-                        {
-                          id: ServarrAction.UNMONITOR_DELETE_ALL,
-                          name: 'Unmonitor and delete files',
-                        },
-                        {
-                          id: ServarrAction.UNMONITOR,
-                          name: 'Unmonitor and keep files',
-                        },
-                        {
-                          id: ServarrAction.DO_NOTHING,
-                          name: 'Do nothing',
-                        },
-                        {
-                          id: ServarrAction.CHANGE_QUALITY_PROFILE,
-                          name: 'Change quality profile and search',
-                        },
-                      ]}
+                      options={RADARR_ACTION_OPTIONS}
                     />
                   )}
 
                   {selectedLibraryType &&
                     selectedLibraryType === 'movie' &&
+                    hasSelectedRadarrServer &&
                     arrActionValue === ServarrAction.CHANGE_QUALITY_PROFILE && (
                       <QualityProfileSelector
                         type="Radarr"
@@ -852,79 +924,16 @@ const AddModal = (props: AddModal) => {
                         mediaServerName={mediaServerName}
                         arrAction={arrActionValue}
                         settingId={sonarrSettingsId}
-                        onUpdate={(e: number, settingId) => {
+                        onUpdate={(e: number, settingId?: number | null) => {
                           handleUpdateArrAction('Sonarr', e, settingId)
                         }}
                         options={
                           selectedType === 'show'
-                            ? [
-                                {
-                                  id: ServarrAction.DELETE,
-                                  name: 'Delete entire show',
-                                },
-                                {
-                                  id: ServarrAction.UNMONITOR_DELETE_ALL,
-                                  name: 'Unmonitor show + seasons, delete all episodes',
-                                },
-                                {
-                                  id: ServarrAction.UNMONITOR_DELETE_EXISTING,
-                                  name: 'Unmonitor show, delete existing episodes',
-                                },
-                                {
-                                  id: ServarrAction.UNMONITOR,
-                                  name: 'Unmonitor show + seasons, keep files',
-                                },
-                                {
-                                  id: ServarrAction.DO_NOTHING,
-                                  name: 'Do nothing',
-                                },
-                                {
-                                  id: ServarrAction.CHANGE_QUALITY_PROFILE,
-                                  name: 'Change quality profile and search',
-                                },
-                              ]
+                            ? SONARR_SHOW_ACTION_OPTIONS
                             : selectedType === 'season'
-                              ? [
-                                  {
-                                    id: ServarrAction.DELETE,
-                                    name: 'Unmonitor and delete season',
-                                  },
-                                  {
-                                    id: ServarrAction.DELETE_SHOW_IF_EMPTY,
-                                    name: 'Unmonitor and delete season + delete show if empty',
-                                  },
-                                  {
-                                    id: ServarrAction.UNMONITOR_DELETE_EXISTING,
-                                    name: 'Unmonitor and delete existing episodes',
-                                  },
-                                  {
-                                    id: ServarrAction.UNMONITOR,
-                                    name: 'Unmonitor season and keep files',
-                                  },
-                                  {
-                                    id: ServarrAction.UNMONITOR_SHOW_IF_EMPTY,
-                                    name: 'Unmonitor season + unmonitor show if empty',
-                                  },
-                                  {
-                                    id: ServarrAction.DO_NOTHING,
-                                    name: 'Do nothing',
-                                  },
-                                ]
+                              ? SONARR_SEASON_ACTION_OPTIONS
                               : // episodes
-                                [
-                                  {
-                                    id: ServarrAction.DELETE,
-                                    name: 'Unmonitor and delete episode',
-                                  },
-                                  {
-                                    id: ServarrAction.UNMONITOR,
-                                    name: 'Unmonitor and keep file',
-                                  },
-                                  {
-                                    id: ServarrAction.DO_NOTHING,
-                                    name: 'Do nothing',
-                                  },
-                                ]
+                                SONARR_EPISODE_ACTION_OPTIONS
                         }
                       />
                       {errors.sonarrSettingsId && (
@@ -933,18 +942,22 @@ const AddModal = (props: AddModal) => {
                         </p>
                       )}
 
-                      {arrActionValue ===
-                        ServarrAction.CHANGE_QUALITY_PROFILE && (
-                        <QualityProfileSelector
-                          type="Sonarr"
-                          settingId={sonarrSettingsId}
-                          qualityProfileId={sonarrQualityProfileId}
-                          onUpdate={(qualityProfileId) => {
-                            setValue('sonarrQualityProfileId', qualityProfileId)
-                          }}
-                          error={errors.sonarrQualityProfileId?.message}
-                        />
-                      )}
+                      {hasSelectedSonarrServer &&
+                        arrActionValue ===
+                          ServarrAction.CHANGE_QUALITY_PROFILE && (
+                          <QualityProfileSelector
+                            type="Sonarr"
+                            settingId={sonarrSettingsId}
+                            qualityProfileId={sonarrQualityProfileId}
+                            onUpdate={(qualityProfileId) => {
+                              setValue(
+                                'sonarrQualityProfileId',
+                                qualityProfileId,
+                              )
+                            }}
+                            error={errors.sonarrQualityProfileId?.message}
+                          />
+                        )}
                     </>
                   )}
 


### PR DESCRIPTION
### Description & Design

Refines the rule-group Add Modal so *arr action behavior stays consistent.

- keeps fallback media-server actions when no Radarr/Sonarr server is selected
- only exposes quality-profile behavior when a matching *arr server is selected
- clears stale quality-profile values when the selected server changes
- keeps action options alphabetized using shared static lists