### PR TITLE
fix: remove SSRF sinks from API failure logging

### DIFF
--- a/apps/server/src/modules/api/external-api/external-api.service.spec.ts
+++ b/apps/server/src/modules/api/external-api/external-api.service.spec.ts
@@ -7,23 +7,6 @@ describe('ExternalApiService', () => {
     warn: jest.fn(),
   });
 
-  it('rejects base URLs that do not use http or https', () => {
-    expect(
-      () => new ExternalApiService('ftp://example.test', {}, createLogger() as any),
-    ).toThrow('External API base URL must use http:// or https://');
-  });
-
-  it('rejects base URLs with embedded credentials', () => {
-    expect(
-      () =>
-        new ExternalApiService(
-          'https://user:pass@example.test',
-          {},
-          createLogger() as any,
-        ),
-    ).toThrow('External API base URL must not include embedded credentials');
-  });
-
   it('logs a single debug line for expected 404 GET failures', async () => {
     const logger = createLogger();
     const service = new ExternalApiService(

--- a/apps/server/src/modules/api/external-api/external-api.service.spec.ts
+++ b/apps/server/src/modules/api/external-api/external-api.service.spec.ts
@@ -7,6 +7,23 @@ describe('ExternalApiService', () => {
     warn: jest.fn(),
   });
 
+  it('rejects base URLs that do not use http or https', () => {
+    expect(
+      () => new ExternalApiService('ftp://example.test', {}, createLogger() as any),
+    ).toThrow('External API base URL must use http:// or https://');
+  });
+
+  it('rejects base URLs with embedded credentials', () => {
+    expect(
+      () =>
+        new ExternalApiService(
+          'https://user:pass@example.test',
+          {},
+          createLogger() as any,
+        ),
+    ).toThrow('External API base URL must not include embedded credentials');
+  });
+
   it('logs a single debug line for expected 404 GET failures', async () => {
     const logger = createLogger();
     const service = new ExternalApiService(
@@ -31,7 +48,6 @@ describe('ExternalApiService', () => {
           } as any,
         ),
       ),
-      getUri: jest.fn().mockReturnValue('https://example.test/items/123'),
     };
 
     await expect(service.get('/items/123')).resolves.toBeUndefined();
@@ -55,7 +71,6 @@ describe('ExternalApiService', () => {
 
     (service as any).axios = {
       get: jest.fn().mockRejectedValue(error),
-      getUri: jest.fn().mockReturnValue('https://example.test/items/123'),
     };
 
     await expect(service.get('/items/123')).resolves.toBeUndefined();

--- a/apps/server/src/modules/api/external-api/external-api.service.ts
+++ b/apps/server/src/modules/api/external-api/external-api.service.ts
@@ -2,6 +2,10 @@ import axios, { AxiosError, AxiosInstance, RawAxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';
 import NodeCache from 'node-cache';
 import { MaintainerrLogger } from '../../logging/logs.service';
+import {
+  describeRequestTarget,
+  normalizeExternalApiBaseUrl,
+} from '../lib/requestLogging';
 
 // 20 minute default TTL (in seconds)
 const DEFAULT_TTL = 1200;
@@ -25,8 +29,10 @@ export class ExternalApiService {
     protected readonly logger: MaintainerrLogger,
     options: ExternalAPIOptions = {},
   ) {
+    const normalizedBaseUrl = normalizeExternalApiBaseUrl(baseUrl);
+
     this.axios = axios.create({
-      baseURL: baseUrl,
+      baseURL: normalizedBaseUrl,
       params,
       timeout: 10000, // timeout after 10s
       headers: {
@@ -39,7 +45,7 @@ export class ExternalApiService {
       retries: 3,
       retryDelay: axiosRetry.exponentialDelay,
     });
-    this.baseUrl = baseUrl;
+    this.baseUrl = normalizedBaseUrl;
     this.cache = options.nodeCache;
   }
 
@@ -170,7 +176,7 @@ export class ExternalApiService {
     config?: RawAxiosRequestConfig,
     ttl?: number,
   ): Promise<T | undefined> {
-    const url = this.axios.getUri({ ...config, url: endpoint });
+    const url = describeRequestTarget(this.baseUrl, endpoint, config);
 
     try {
       const cacheKey = this.serializeCacheKey(
@@ -236,7 +242,7 @@ export class ExternalApiService {
     config: RawAxiosRequestConfig | undefined,
     error: unknown,
   ) {
-    const url = this.axios.getUri({ ...config, url: endpoint });
+    const url = describeRequestTarget(this.baseUrl, endpoint, config);
     this.logger.debug(this.formatRequestFailure(method, url, error));
   }
 

--- a/apps/server/src/modules/api/external-api/external-api.service.ts
+++ b/apps/server/src/modules/api/external-api/external-api.service.ts
@@ -2,10 +2,7 @@ import axios, { AxiosError, AxiosInstance, RawAxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';
 import NodeCache from 'node-cache';
 import { MaintainerrLogger } from '../../logging/logs.service';
-import {
-  describeRequestTarget,
-  normalizeExternalApiBaseUrl,
-} from '../lib/requestLogging';
+import { describeRequestTarget } from '../lib/requestLogging';
 
 // 20 minute default TTL (in seconds)
 const DEFAULT_TTL = 1200;
@@ -29,10 +26,8 @@ export class ExternalApiService {
     protected readonly logger: MaintainerrLogger,
     options: ExternalAPIOptions = {},
   ) {
-    const normalizedBaseUrl = normalizeExternalApiBaseUrl(baseUrl);
-
     this.axios = axios.create({
-      baseURL: normalizedBaseUrl,
+      baseURL: baseUrl,
       params,
       timeout: 10000, // timeout after 10s
       headers: {
@@ -45,7 +40,7 @@ export class ExternalApiService {
       retries: 3,
       retryDelay: axiosRetry.exponentialDelay,
     });
-    this.baseUrl = normalizedBaseUrl;
+    this.baseUrl = baseUrl;
     this.cache = options.nodeCache;
   }
 

--- a/apps/server/src/modules/api/lib/plexApi.ts
+++ b/apps/server/src/modules/api/lib/plexApi.ts
@@ -2,10 +2,7 @@ import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';
 import { PlexLibraryResponse } from '../plex-api/interfaces/library.interfaces';
 import cacheManager, { Cache } from './cache';
-import {
-  describeRequestTarget,
-  normalizeExternalApiBaseUrl,
-} from './requestLogging';
+import { describeRequestTarget } from './requestLogging';
 
 type PlexApiOptions = {
   hostname: string;
@@ -29,9 +26,8 @@ class PlexApi {
     this.options = options;
     this.cache = cacheManager.getCache('plexguid');
 
-    const baseURL = normalizeExternalApiBaseUrl(
-      this.getServerScheme() + options.hostname + ':' + options.port,
-    );
+    const baseURL =
+      this.getServerScheme() + options.hostname + ':' + options.port;
 
     this.axios = axios.create({
       baseURL,

--- a/apps/server/src/modules/api/lib/plexApi.ts
+++ b/apps/server/src/modules/api/lib/plexApi.ts
@@ -2,6 +2,10 @@ import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';
 import { PlexLibraryResponse } from '../plex-api/interfaces/library.interfaces';
 import cacheManager, { Cache } from './cache';
+import {
+  describeRequestTarget,
+  normalizeExternalApiBaseUrl,
+} from './requestLogging';
 
 type PlexApiOptions = {
   hostname: string;
@@ -25,8 +29,9 @@ class PlexApi {
     this.options = options;
     this.cache = cacheManager.getCache('plexguid');
 
-    const baseURL =
-      this.getServerScheme() + options.hostname + ':' + options.port;
+    const baseURL = normalizeExternalApiBaseUrl(
+      this.getServerScheme() + options.hostname + ':' + options.port,
+    );
 
     this.axios = axios.create({
       baseURL,
@@ -149,7 +154,10 @@ class PlexApi {
       const response = await this.axios.request(requestConfig);
       return response.data as T;
     } catch (error) {
-      const url = this.axios.getUri(requestConfig);
+      const url = describeRequestTarget(
+        this.axios.defaults.baseURL,
+        options.uri,
+      );
 
       if (error instanceof AxiosError) {
         if (error.response?.status === 403) {

--- a/apps/server/src/modules/api/lib/requestLogging.ts
+++ b/apps/server/src/modules/api/lib/requestLogging.ts
@@ -1,0 +1,58 @@
+export interface RequestTargetConfig {
+  baseURL?: string;
+  params?: unknown;
+}
+
+export function normalizeExternalApiBaseUrl(baseUrl: string): string {
+  const parsedUrl = new URL(baseUrl);
+
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new Error('External API base URL must use http:// or https://');
+  }
+
+  if (parsedUrl.username || parsedUrl.password) {
+    throw new Error(
+      'External API base URL must not include embedded credentials',
+    );
+  }
+
+  parsedUrl.hash = '';
+
+  let normalizedUrl = parsedUrl.toString();
+  while (normalizedUrl.endsWith('/')) normalizedUrl = normalizedUrl.slice(0, -1);
+
+  return normalizedUrl;
+}
+
+export function describeRequestTarget(
+  fallbackBaseURL: string | undefined,
+  endpoint: string | undefined,
+  config?: RequestTargetConfig,
+): string {
+  let base = config?.baseURL ?? fallbackBaseURL ?? '';
+  while (base.endsWith('/')) base = base.slice(0, -1);
+
+  let path = endpoint ?? '';
+  while (path.startsWith('/')) path = path.slice(1);
+
+  let target: string;
+  if (!base) target = '/' + path;
+  else if (!path) target = base;
+  else target = base + '/' + path;
+
+  const query = serializeParams(config?.params);
+  if (query) target += (target.includes('?') ? '&' : '?') + query;
+  return target;
+}
+
+function serializeParams(params: unknown): string {
+  if (!params || typeof params !== 'object') return '';
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
+    if (value === undefined || value === null) continue;
+    parts.push(
+      encodeURIComponent(key) + '=' + encodeURIComponent(String(value)),
+    );
+  }
+  return parts.join('&');
+}

--- a/apps/server/src/modules/api/lib/requestLogging.ts
+++ b/apps/server/src/modules/api/lib/requestLogging.ts
@@ -3,27 +3,6 @@ export interface RequestTargetConfig {
   params?: unknown;
 }
 
-export function normalizeExternalApiBaseUrl(baseUrl: string): string {
-  const parsedUrl = new URL(baseUrl);
-
-  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-    throw new Error('External API base URL must use http:// or https://');
-  }
-
-  if (parsedUrl.username || parsedUrl.password) {
-    throw new Error(
-      'External API base URL must not include embedded credentials',
-    );
-  }
-
-  parsedUrl.hash = '';
-
-  let normalizedUrl = parsedUrl.toString();
-  while (normalizedUrl.endsWith('/')) normalizedUrl = normalizedUrl.slice(0, -1);
-
-  return normalizedUrl;
-}
-
 export function describeRequestTarget(
   fallbackBaseURL: string | undefined,
   endpoint: string | undefined,
@@ -48,7 +27,9 @@ export function describeRequestTarget(
 function serializeParams(params: unknown): string {
   if (!params || typeof params !== 'object') return '';
   const parts: string[] = [];
-  for (const [key, value] of Object.entries(params as Record<string, unknown>)) {
+  for (const [key, value] of Object.entries(
+    params as Record<string, unknown>,
+  )) {
     if (value === undefined || value === null) continue;
     parts.push(
       encodeURIComponent(key) + '=' + encodeURIComponent(String(value)),

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -221,25 +221,6 @@ describe('JellyfinAdapterService', () => {
     return error;
   };
 
-  describe('URL validation', () => {
-    it('rejects unsupported URL schemes when testing a connection', async () => {
-      await expect(
-        service.testConnection('ftp://jellyfin.test:8096', 'test-api-key'),
-      ).rejects.toThrow('External API base URL must use http:// or https://');
-    });
-
-    it('rejects embedded credentials when testing a connection', async () => {
-      await expect(
-        service.testConnection(
-          'https://user:pass@jellyfin.test:8096',
-          'test-api-key',
-        ),
-      ).rejects.toThrow(
-        'External API base URL must not include embedded credentials',
-      );
-    });
-  });
-
   const createResponseError = (status: number): AxiosError => {
     const error = new AxiosError(`request failed with status ${status}`);
     Object.assign(error, {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.spec.ts
@@ -221,6 +221,25 @@ describe('JellyfinAdapterService', () => {
     return error;
   };
 
+  describe('URL validation', () => {
+    it('rejects unsupported URL schemes when testing a connection', async () => {
+      await expect(
+        service.testConnection('ftp://jellyfin.test:8096', 'test-api-key'),
+      ).rejects.toThrow('External API base URL must use http:// or https://');
+    });
+
+    it('rejects embedded credentials when testing a connection', async () => {
+      await expect(
+        service.testConnection(
+          'https://user:pass@jellyfin.test:8096',
+          'test-api-key',
+        ),
+      ).rejects.toThrow(
+        'External API base URL must not include embedded credentials',
+      );
+    });
+  });
+
   const createResponseError = (status: number): AxiosError => {
     const error = new AxiosError(`request failed with status ${status}`);
     Object.assign(error, {

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -46,7 +46,6 @@ import { delay } from '../../../../utils/delay';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { SettingsService } from '../../../settings/settings.service';
 import cacheManager, { type Cache } from '../../lib/cache';
-import { normalizeExternalApiBaseUrl } from '../../lib/requestLogging';
 import {
   isBlankMediaServerId,
   isForeignServerId,
@@ -130,8 +129,6 @@ export class JellyfinAdapterService implements IMediaServerService {
     apiKey: string,
     deviceSuffix: string = 'default',
   ): Api {
-    const normalizedUrl = normalizeExternalApiBaseUrl(url);
-
     const jellyfin = new Jellyfin({
       clientInfo: {
         name: JELLYFIN_CLIENT_INFO.name,
@@ -143,7 +140,7 @@ export class JellyfinAdapterService implements IMediaServerService {
       },
     });
 
-    return jellyfin.createApi(normalizedUrl, apiKey);
+    return jellyfin.createApi(url, apiKey);
   }
 
   /**

--- a/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
+++ b/apps/server/src/modules/api/media-server/jellyfin/jellyfin-adapter.service.ts
@@ -2,8 +2,8 @@ import { Jellyfin, type Api } from '@jellyfin/sdk';
 import {
   BaseItemKind,
   ItemFields,
-  LocationType,
   ItemSortBy,
+  LocationType,
   SortOrder,
   type UserItemDataDto,
 } from '@jellyfin/sdk/lib/generated-client/models';
@@ -46,6 +46,7 @@ import { delay } from '../../../../utils/delay';
 import { MaintainerrLogger } from '../../../logging/logs.service';
 import { SettingsService } from '../../../settings/settings.service';
 import cacheManager, { type Cache } from '../../lib/cache';
+import { normalizeExternalApiBaseUrl } from '../../lib/requestLogging';
 import {
   isBlankMediaServerId,
   isForeignServerId,
@@ -129,6 +130,8 @@ export class JellyfinAdapterService implements IMediaServerService {
     apiKey: string,
     deviceSuffix: string = 'default',
   ): Api {
+    const normalizedUrl = normalizeExternalApiBaseUrl(url);
+
     const jellyfin = new Jellyfin({
       clientInfo: {
         name: JELLYFIN_CLIENT_INFO.name,
@@ -140,7 +143,7 @@ export class JellyfinAdapterService implements IMediaServerService {
       },
     });
 
-    return jellyfin.createApi(url, apiKey);
+    return jellyfin.createApi(normalizedUrl, apiKey);
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes the critical CodeQL `js/server-side-request-forgery` alert on [external-api.service.ts](apps/server/src/modules/api/external-api/external-api.service.ts) that was blocking #2664.

The alert fired because `axios.getUri({ ...config, url: endpoint })` was called purely to build a string for failure log messages. CodeQL treats `getUri` as a URL-construction sink, so user-provided `endpoint` flowing into it lit up as SSRF — even though the result only ever reached `logger.debug`.

## Changes

- New `lib/requestLogging.ts` → `describeRequestTarget(fallbackBaseURL, endpoint, config?)`: builds a log-safe `base + path + query` string with plain string ops and `encodeURIComponent`. No URL parser, no `getUri`.
- [external-api.service.ts](apps/server/src/modules/api/external-api/external-api.service.ts): `logRequestFailure` and `postRolling` use the helper. Per-request `baseURL` overrides and `config.params` are still reflected in failure logs.
- [lib/plexApi.ts](apps/server/src/modules/api/lib/plexApi.ts): same helper on the error path.

Every subclass of `ExternalApiService` (servarr, seerr, tautulli, tmdb, tvdb, plextv, plexCommunity, internal) inherits the fix automatically.

## Notes

- Log format is unchanged and now preserves per-request context (plextv `metadata.provider.plex.tv` baseURL overrides, tautulli `cmd=...` params) that a naive fix would have lost.
- No request-path behavior change — only how the target string is built for logs.
- An earlier iteration added a `normalizeExternalApiBaseUrl` helper using `new URL(baseUrl)`. CodeQL treated that as a new URL-construction sink and started flagging every downstream axios request. Reverted to keep the fix minimal.

## Test plan

- [x] Server tests pass (external-api, plex-api, jellyfin-adapter specs)
- [x] `yarn build` green
- [x] `yarn format:check` green
- [x] CodeQL re-run confirms the SSRF alert is cleared with no new findings