### PR TITLE
fix: handle media server unreachable in rule UI

### DIFF
--- a/apps/server/src/modules/api/media-server/media-server.controller.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-server.controller.spec.ts
@@ -1,5 +1,8 @@
 import { MediaItem } from '@maintainerr/contracts';
-import { BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { MediaItemEnrichmentService } from './media-item-enrichment.service';
 import { MediaServerController } from './media-server.controller';
@@ -433,6 +436,41 @@ describe('MediaServerController', () => {
       );
 
       expect(result.content.items).toEqual([bravo, alpha]);
+    });
+  });
+
+  describe('getLibraries - Unreachable Detection', () => {
+    it('throws ServiceUnavailableException when configured but unreachable', async () => {
+      mockMediaServerService.getLibraries.mockResolvedValue([]);
+      (mockMediaServerService as any).isSetup = jest.fn().mockReturnValue(true);
+      (mockMediaServerService as any).getStatus = jest
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await expect(controller.getLibraries()).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('returns an empty list when the server is reachable but has zero libraries', async () => {
+      mockMediaServerService.getLibraries.mockResolvedValue([]);
+      (mockMediaServerService as any).isSetup = jest.fn().mockReturnValue(true);
+      (mockMediaServerService as any).getStatus = jest
+        .fn()
+        .mockResolvedValue({ machineId: 'm1', version: '1' });
+
+      await expect(controller.getLibraries()).resolves.toEqual([]);
+    });
+
+    it('skips the status probe when the server is not set up', async () => {
+      mockMediaServerService.getLibraries.mockResolvedValue([]);
+      (mockMediaServerService as any).isSetup = jest
+        .fn()
+        .mockReturnValue(false);
+      (mockMediaServerService as any).getStatus = jest.fn();
+
+      await expect(controller.getLibraries()).resolves.toEqual([]);
+      expect((mockMediaServerService as any).getStatus).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/modules/api/media-server/media-server.controller.spec.ts
+++ b/apps/server/src/modules/api/media-server/media-server.controller.spec.ts
@@ -29,6 +29,7 @@ describe('MediaServerController', () => {
   beforeEach(() => {
     mockMediaServerService = {
       getLibraries: jest.fn().mockResolvedValue([]),
+      getStatus: jest.fn().mockResolvedValue(undefined),
       getLibraryContents: jest.fn().mockResolvedValue({
         items: [],
         totalSize: 0,
@@ -38,6 +39,7 @@ describe('MediaServerController', () => {
       searchContent: jest.fn().mockResolvedValue([]),
       searchLibraryContents: jest.fn().mockResolvedValue([]),
       getMetadata: jest.fn().mockResolvedValue(undefined),
+      isSetup: jest.fn().mockReturnValue(false),
       updateCollectionVisibility: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<IMediaServerService>;
 
@@ -442,10 +444,8 @@ describe('MediaServerController', () => {
   describe('getLibraries - Unreachable Detection', () => {
     it('throws ServiceUnavailableException when configured but unreachable', async () => {
       mockMediaServerService.getLibraries.mockResolvedValue([]);
-      (mockMediaServerService as any).isSetup = jest.fn().mockReturnValue(true);
-      (mockMediaServerService as any).getStatus = jest
-        .fn()
-        .mockResolvedValue(undefined);
+      mockMediaServerService.isSetup.mockReturnValue(true);
+      mockMediaServerService.getStatus.mockResolvedValue(undefined);
 
       await expect(controller.getLibraries()).rejects.toThrow(
         ServiceUnavailableException,
@@ -454,23 +454,33 @@ describe('MediaServerController', () => {
 
     it('returns an empty list when the server is reachable but has zero libraries', async () => {
       mockMediaServerService.getLibraries.mockResolvedValue([]);
-      (mockMediaServerService as any).isSetup = jest.fn().mockReturnValue(true);
-      (mockMediaServerService as any).getStatus = jest
-        .fn()
-        .mockResolvedValue({ machineId: 'm1', version: '1' });
+      mockMediaServerService.isSetup.mockReturnValue(true);
+      mockMediaServerService.getStatus.mockResolvedValue({
+        machineId: 'm1',
+        version: '1',
+      });
 
       await expect(controller.getLibraries()).resolves.toEqual([]);
     });
 
     it('skips the status probe when the server is not set up', async () => {
       mockMediaServerService.getLibraries.mockResolvedValue([]);
-      (mockMediaServerService as any).isSetup = jest
-        .fn()
-        .mockReturnValue(false);
-      (mockMediaServerService as any).getStatus = jest.fn();
+      mockMediaServerService.isSetup.mockReturnValue(false);
 
       await expect(controller.getLibraries()).resolves.toEqual([]);
-      expect((mockMediaServerService as any).getStatus).not.toHaveBeenCalled();
+      expect(mockMediaServerService.getStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getOverviewBootstrap - Unreachable Detection', () => {
+    it('throws ServiceUnavailableException when configured but unreachable', async () => {
+      mockMediaServerService.getLibraries.mockResolvedValue([]);
+      mockMediaServerService.isSetup.mockReturnValue(true);
+      mockMediaServerService.getStatus.mockResolvedValue(undefined);
+
+      await expect(controller.getOverviewBootstrap(30)).rejects.toThrow(
+        ServiceUnavailableException,
+      );
     });
   });
 

--- a/apps/server/src/modules/api/media-server/media-server.controller.ts
+++ b/apps/server/src/modules/api/media-server/media-server.controller.ts
@@ -31,6 +31,7 @@ import {
   Post,
   Put,
   Query,
+  ServiceUnavailableException,
   UseGuards,
 } from '@nestjs/common';
 import { ZodValidationPipe } from 'nestjs-zod';
@@ -213,7 +214,22 @@ export class MediaServerController {
   @Get('libraries')
   async getLibraries(): Promise<MediaLibrary[]> {
     const mediaServer = await this.mediaServerFactory.getService();
-    return await mediaServer.getLibraries();
+    const libraries = await mediaServer.getLibraries();
+
+    // Distinguish "server unreachable" from "server healthy but no libraries".
+    // Adapters swallow upstream failures and return []; without this check the
+    // UI would render as though the media server has zero libraries, hiding
+    // any rule groups referencing a stored libraryId.
+    if (libraries.length === 0 && mediaServer.isSetup()) {
+      const status = await mediaServer.getStatus();
+      if (!status) {
+        throw new ServiceUnavailableException(
+          'Media server is configured but unreachable. Library list unavailable.',
+        );
+      }
+    }
+
+    return libraries;
   }
 
   @Get('overview/bootstrap')

--- a/apps/server/src/modules/api/media-server/media-server.controller.ts
+++ b/apps/server/src/modules/api/media-server/media-server.controller.ts
@@ -199,21 +199,9 @@ export class MediaServerController {
     };
   }
 
-  @Get()
-  async getStatus(): Promise<MediaServerStatus | undefined> {
-    const mediaServer = await this.mediaServerFactory.getService();
-    return mediaServer.getStatus();
-  }
-
-  @Get('type')
-  async getServerType(): Promise<{ type: string }> {
-    const mediaServer = await this.mediaServerFactory.getService();
-    return { type: mediaServer.getServerType() };
-  }
-
-  @Get('libraries')
-  async getLibraries(): Promise<MediaLibrary[]> {
-    const mediaServer = await this.mediaServerFactory.getService();
+  private async getLibrariesOrThrowUnavailable(
+    mediaServer: IMediaServerService,
+  ): Promise<MediaLibrary[]> {
     const libraries = await mediaServer.getLibraries();
 
     // Distinguish "server unreachable" from "server healthy but no libraries".
@@ -232,6 +220,24 @@ export class MediaServerController {
     return libraries;
   }
 
+  @Get()
+  async getStatus(): Promise<MediaServerStatus | undefined> {
+    const mediaServer = await this.mediaServerFactory.getService();
+    return mediaServer.getStatus();
+  }
+
+  @Get('type')
+  async getServerType(): Promise<{ type: string }> {
+    const mediaServer = await this.mediaServerFactory.getService();
+    return { type: mediaServer.getServerType() };
+  }
+
+  @Get('libraries')
+  async getLibraries(): Promise<MediaLibrary[]> {
+    const mediaServer = await this.mediaServerFactory.getService();
+    return await this.getLibrariesOrThrowUnavailable(mediaServer);
+  }
+
   @Get('overview/bootstrap')
   async getOverviewBootstrap(
     @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
@@ -241,7 +247,7 @@ export class MediaServerController {
     sortOrder?: MediaSortOrder,
   ): Promise<OverviewBootstrapResult> {
     const mediaServer = await this.mediaServerFactory.getService();
-    const libraries = await mediaServer.getLibraries();
+    const libraries = await this.getLibrariesOrThrowUnavailable(mediaServer);
     const selectedLibrary = libraries[0];
     const size = limit ?? 50;
 

--- a/apps/ui/src/api/media-server.ts
+++ b/apps/ui/src/api/media-server.ts
@@ -63,6 +63,10 @@ export const useMediaServerLibraries = (
       return await GetApiHandler<MediaLibrary[]>('/media-server/libraries')
     },
     staleTime: 0,
+    // Keep retries minimal so an unreachable media server surfaces as an
+    // error quickly instead of blocking rule/collection UIs behind the
+    // TanStack Query default of 3 retries.
+    retry: 1,
     ...options,
   })
 }

--- a/apps/ui/src/components/Collection/CollectionItem/index.spec.tsx
+++ b/apps/ui/src/components/Collection/CollectionItem/index.spec.tsx
@@ -147,6 +147,41 @@ describe('CollectionItem', () => {
     expect(openDetail).toHaveBeenCalledTimes(1)
   })
 
+  it('shows "Unavailable" in warning style when libraries query errored and the id is unresolved', () => {
+    librariesHookMock.mockReturnValue({
+      data: undefined,
+      error: new Error('offline'),
+      isError: true,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useMediaServerLibraries>)
+
+    render(
+      <CollectionItem
+        collection={
+          {
+            id: 1,
+            title: 'Action',
+            libraryId: 'library-1',
+            description: 'Collection description',
+            isActive: true,
+            type: 'movie',
+            arrAction: 0,
+            media: [],
+            manualCollection: false,
+            manualCollectionName: '',
+            addDate: new Date(),
+            handledMediaAmount: 0,
+            lastDurationInSeconds: 0,
+            keepLogsForMonths: 0,
+          } as any
+        }
+      />,
+    )
+
+    const label = screen.getByText('Unavailable')
+    expect(label.className).toContain('text-warning-500')
+  })
+
   it('does not render a collection modal when no detail handler is provided', () => {
     render(
       <CollectionItem

--- a/apps/ui/src/components/Collection/CollectionItem/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionItem/index.tsx
@@ -1,7 +1,7 @@
 import { MediaItemTypeLabels } from '@maintainerr/contracts'
 import { useEffect, useMemo, useState } from 'react'
 import { ICollection } from '..'
-import { useMediaServerLibraries } from '../../../api/media-server'
+import { useLibraryDisplay } from '../../../hooks/useLibraryDisplay'
 import GetApiHandler from '../../../utils/ApiHandler'
 import {
   buildMetadataImagePath,
@@ -24,11 +24,8 @@ function formatSize(bytes: number | null | undefined): string {
 }
 
 const CollectionItem = (props: ICollectionItem) => {
-  const { data: libraries, isError: librariesError } = useMediaServerLibraries()
-  const resolvedLibraryTitle = libraries?.find(
-    (lib) => String(lib.id) === String(props.collection.libraryId),
-  )?.title
-  const libraryUnreachable = !resolvedLibraryTitle && librariesError
+  const { title: resolvedLibraryTitle, isUnreachable: libraryUnreachable } =
+    useLibraryDisplay(props.collection.libraryId)
   const libraryTitle =
     resolvedLibraryTitle ?? (libraryUnreachable ? 'Unavailable' : '-')
   const deleteAfterLabel =

--- a/apps/ui/src/components/Collection/CollectionItem/index.tsx
+++ b/apps/ui/src/components/Collection/CollectionItem/index.tsx
@@ -24,11 +24,13 @@ function formatSize(bytes: number | null | undefined): string {
 }
 
 const CollectionItem = (props: ICollectionItem) => {
-  const { data: libraries } = useMediaServerLibraries()
+  const { data: libraries, isError: librariesError } = useMediaServerLibraries()
+  const resolvedLibraryTitle = libraries?.find(
+    (lib) => String(lib.id) === String(props.collection.libraryId),
+  )?.title
+  const libraryUnreachable = !resolvedLibraryTitle && librariesError
   const libraryTitle =
-    libraries?.find(
-      (lib) => String(lib.id) === String(props.collection.libraryId),
-    )?.title ?? '-'
+    resolvedLibraryTitle ?? (libraryUnreachable ? 'Unavailable' : '-')
   const deleteAfterLabel =
     props.collection.deleteAfterDays == null
       ? 'Never'
@@ -159,7 +161,18 @@ const CollectionItem = (props: ICollectionItem) => {
             <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
               Library
             </p>
-            <p className="truncate text-maintainerr" title={libraryTitle}>
+            <p
+              className={
+                libraryUnreachable
+                  ? 'truncate text-warning-500'
+                  : 'truncate text-maintainerr'
+              }
+              title={
+                libraryUnreachable
+                  ? 'Media server is unreachable. The stored library selection is preserved.'
+                  : libraryTitle
+              }
+            >
               {libraryTitle}
             </p>
           </div>

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.spec.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.spec.tsx
@@ -1,6 +1,6 @@
 import { ServarrAction } from '@maintainerr/contracts'
 import { describe, expect, it } from 'vitest'
-import { ruleGroupFormSchema } from './index'
+import { getStoredLibraryFallbackState, ruleGroupFormSchema } from './index'
 
 describe('ruleGroupFormSchema', () => {
   it('allows missing arr server selection for fallback media server delete actions', () => {
@@ -67,5 +67,38 @@ describe('ruleGroupFormSchema', () => {
     expect(result.error.flatten().fieldErrors.radarrQualityProfileId).toContain(
       'Quality profile is required for this action',
     )
+  })
+
+  it('does not show the stored-library fallback while libraries are still loading', () => {
+    expect(
+      getStoredLibraryFallbackState('library-1', undefined, true, false),
+    ).toEqual({
+      storedLibraryResolved: false,
+      storedLibraryMissing: false,
+      showStoredLibraryFallback: false,
+    })
+  })
+
+  it('shows the stored-library fallback when loading finished without the stored id or the query errored', () => {
+    expect(
+      getStoredLibraryFallbackState('library-1', undefined, false, true),
+    ).toEqual({
+      storedLibraryResolved: false,
+      storedLibraryMissing: true,
+      showStoredLibraryFallback: true,
+    })
+
+    expect(
+      getStoredLibraryFallbackState(
+        'library-1',
+        [{ id: 'library-2', title: 'Shows', type: 'show' }],
+        false,
+        false,
+      ),
+    ).toEqual({
+      storedLibraryResolved: false,
+      storedLibraryMissing: true,
+      showStoredLibraryFallback: true,
+    })
   })
 })

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -57,6 +57,27 @@ interface AddModal {
   onSuccess: () => void
 }
 
+export const getStoredLibraryFallbackState = (
+  storedLibraryId: string | undefined,
+  libraries: MediaLibrary[] | undefined,
+  librariesLoading: boolean,
+  librariesError: boolean,
+) => {
+  const storedLibraryResolved = Boolean(
+    storedLibraryId && libraries?.some((lib) => lib.id === storedLibraryId),
+  )
+  const storedLibraryMissing =
+    !!storedLibraryId && !librariesLoading && !storedLibraryResolved
+  const showStoredLibraryFallback =
+    !!storedLibraryId && (librariesError || storedLibraryMissing)
+
+  return {
+    storedLibraryResolved,
+    storedLibraryMissing,
+    showStoredLibraryFallback,
+  }
+}
+
 // Helper function to check if an app should be filtered
 const shouldFilterApp = (
   appId: number,
@@ -461,11 +482,16 @@ const AddModal = (props: AddModal) => {
     isError: librariesError,
   } = useMediaServerLibraries()
   const storedLibraryId = props.editData?.libraryId?.toString()
-  // Show the stored library as a fallback whenever it's not present in the
-  // current libraries list — including during loading/error. This keeps the
-  // edit form usable when the media server is unreachable on cold load.
-  const storedLibraryMissing =
-    !!storedLibraryId && !libraries?.some((lib) => lib.id === storedLibraryId)
+  const {
+    storedLibraryResolved,
+    storedLibraryMissing,
+    showStoredLibraryFallback,
+  } = getStoredLibraryFallbackState(
+    storedLibraryId,
+    libraries,
+    librariesLoading,
+    librariesError,
+  )
 
   const { data: constants, isLoading: constantsLoading } = useRuleConstants()
 
@@ -482,9 +508,13 @@ const AddModal = (props: AddModal) => {
     constants?.applications?.some((x) => x.id == Application.SEERR) ?? false
 
   function updateLibraryId(value: string) {
-    // Re-selecting the stored library (or selecting it while the server is
-    // unreachable) must not drop existing *arr rules from the form state.
-    if (value === storedLibraryId) {
+    // Selecting the unresolved stored-library fallback keeps the original
+    // library type intact instead of resetting dependent state based on an
+    // entry the media server could not resolve.
+    if (value === storedLibraryId && !storedLibraryResolved) {
+      if (props.editData?.dataType) {
+        setValue('dataType', props.editData.dataType)
+      }
       return
     }
 
@@ -845,7 +875,7 @@ const AddModal = (props: AddModal) => {
                               {selectedLibraryId === '' && (
                                 <option value="" disabled></option>
                               )}
-                              {storedLibraryMissing && storedLibraryId && (
+                              {showStoredLibraryFallback && storedLibraryId && (
                                 <option value={storedLibraryId}>
                                   Stored library (unavailable)
                                 </option>

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -455,8 +455,16 @@ const AddModal = (props: AddModal) => {
   const [formIncomplete, setFormIncomplete] = useState<boolean>(false)
   const [ruleCreatorVersion, setRuleCreatorVersion] = useState<number>(1)
 
-  const { data: libraries, isLoading: librariesLoading } =
-    useMediaServerLibraries()
+  const {
+    data: libraries,
+    isLoading: librariesLoading,
+    isError: librariesError,
+  } = useMediaServerLibraries()
+  const storedLibraryId = props.editData?.libraryId?.toString()
+  const storedLibraryMissing =
+    !!storedLibraryId &&
+    !librariesLoading &&
+    !libraries?.some((lib) => lib.id === storedLibraryId)
 
   const { data: constants, isLoading: constantsLoading } = useRuleConstants()
 
@@ -473,6 +481,12 @@ const AddModal = (props: AddModal) => {
     constants?.applications?.some((x) => x.id == Application.SEERR) ?? false
 
   function updateLibraryId(value: string) {
+    // Re-selecting the stored library (or selecting it while the server is
+    // unreachable) must not drop existing *arr rules from the form state.
+    if (value === storedLibraryId) {
+      return
+    }
+
     if (!libraries) {
       throw new Error('Libraries not loaded')
     }
@@ -824,6 +838,11 @@ const AddModal = (props: AddModal) => {
                               {selectedLibraryId === '' && (
                                 <option value="" disabled></option>
                               )}
+                              {storedLibraryMissing && storedLibraryId && (
+                                <option value={storedLibraryId}>
+                                  Stored library (unavailable)
+                                </option>
+                              )}
                               {libraries?.map((data: MediaLibrary) => {
                                 return (
                                   <option key={data.id} value={data.id}>
@@ -835,6 +854,13 @@ const AddModal = (props: AddModal) => {
                           )
                         })()}
                       </div>
+                      {(librariesError || storedLibraryMissing) && (
+                        <p className="mt-1 text-xs text-warning-500">
+                          {librariesError
+                            ? `Could not load libraries from ${mediaServerName}. The saved library selection is preserved — cancel editing to avoid losing rules.`
+                            : 'The saved library could not be found in the current library list. Re-select it once your media server is reachable.'}
+                        </p>
+                      )}
                       {errors.libraryId && (
                         <p className="mt-1 text-xs text-error-400">
                           {errors.libraryId.message}

--- a/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/AddModal/index.tsx
@@ -461,10 +461,11 @@ const AddModal = (props: AddModal) => {
     isError: librariesError,
   } = useMediaServerLibraries()
   const storedLibraryId = props.editData?.libraryId?.toString()
+  // Show the stored library as a fallback whenever it's not present in the
+  // current libraries list — including during loading/error. This keeps the
+  // edit form usable when the media server is unreachable on cold load.
   const storedLibraryMissing =
-    !!storedLibraryId &&
-    !librariesLoading &&
-    !libraries?.some((lib) => lib.id === storedLibraryId)
+    !!storedLibraryId && !libraries?.some((lib) => lib.id === storedLibraryId)
 
   const { data: constants, isLoading: constantsLoading } = useRuleConstants()
 
@@ -719,7 +720,13 @@ const AddModal = (props: AddModal) => {
     }
   }
 
-  if (librariesLoading || constantsLoading) {
+  // Only hard-block on rule constants: the form can't render its applications,
+  // rule operators, or field options without them. Libraries are allowed to
+  // stream in later — when editing, the stored library is surfaced via
+  // `storedLibraryMissing` so the form remains usable even if the media
+  // server is offline. For brand-new rule groups we still wait for libraries
+  // because there's no fallback selection to preserve.
+  if (constantsLoading || (librariesLoading && !props.editData)) {
     return <LoadingSpinner />
   }
 

--- a/apps/ui/src/components/Rules/RuleGroup/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/index.tsx
@@ -9,12 +9,12 @@ import { isAxiosError } from 'axios'
 import clsx from 'clsx'
 import { useState } from 'react'
 import { toast } from 'react-toastify'
-import { useMediaServerLibraries } from '../../../api/media-server'
 import {
   useExecuteRuleGroup,
   useStopRuleGroupExecution,
 } from '../../../api/rules'
 import { useTaskStatusContext } from '../../../contexts/taskstatus-context'
+import { useLibraryDisplay } from '../../../hooks/useLibraryDisplay'
 import { DeleteApiHandler } from '../../../utils/ApiHandler'
 import { logClientError } from '../../../utils/ClientLogger'
 import { ICollection } from '../../Collection'
@@ -44,7 +44,11 @@ const RuleGroup = (props: {
   onEdit: (group: IRuleGroup) => void
 }) => {
   const [showsureDelete, setShowSureDelete] = useState<boolean>(false)
-  const { data: libraries, isError: librariesError } = useMediaServerLibraries()
+  const {
+    title: libraryTitle,
+    hasLibraryId,
+    isUnreachable: libraryUnreachable,
+  } = useLibraryDisplay(props.group.libraryId)
   const { queueStatus } = useTaskStatusContext()
   const { mutate: executeRules } = useExecuteRuleGroup({
     onError(error) {
@@ -96,12 +100,7 @@ const RuleGroup = (props: {
     queueStatus?.executingRuleGroupId === props.group.id ||
     isQueued ||
     isPending
-  const hasNoLibrary = !props.group.libraryId || props.group.libraryId === ''
-  const libraryTitle = libraries?.find(
-    (lib) => lib.id === props.group.libraryId,
-  )?.title
-  const libraryUnresolved = !hasNoLibrary && !libraryTitle
-  const libraryUnreachable = libraryUnresolved && librariesError
+  const hasNoLibrary = !hasLibraryId
 
   return (
     <>

--- a/apps/ui/src/components/Rules/RuleGroup/index.tsx
+++ b/apps/ui/src/components/Rules/RuleGroup/index.tsx
@@ -44,7 +44,7 @@ const RuleGroup = (props: {
   onEdit: (group: IRuleGroup) => void
 }) => {
   const [showsureDelete, setShowSureDelete] = useState<boolean>(false)
-  const { data: libraries } = useMediaServerLibraries()
+  const { data: libraries, isError: librariesError } = useMediaServerLibraries()
   const { queueStatus } = useTaskStatusContext()
   const { mutate: executeRules } = useExecuteRuleGroup({
     onError(error) {
@@ -97,6 +97,11 @@ const RuleGroup = (props: {
     isQueued ||
     isPending
   const hasNoLibrary = !props.group.libraryId || props.group.libraryId === ''
+  const libraryTitle = libraries?.find(
+    (lib) => lib.id === props.group.libraryId,
+  )?.title
+  const libraryUnresolved = !hasNoLibrary && !libraryTitle
+  const libraryUnreachable = libraryUnresolved && librariesError
 
   return (
     <>
@@ -167,10 +172,16 @@ const RuleGroup = (props: {
                 >
                   Not set
                 </p>
+              ) : libraryUnreachable ? (
+                <p
+                  className="truncate text-warning-500"
+                  title="Media server is unreachable. The stored library selection is preserved."
+                >
+                  Unavailable
+                </p>
               ) : (
                 <p className="truncate text-maintainerr">
-                  {libraries?.find((lib) => lib.id === props.group.libraryId)
-                    ?.title ?? '-'}
+                  {libraryTitle ?? '-'}
                 </p>
               )}
             </div>

--- a/apps/ui/src/hooks/useLibraryDisplay.spec.tsx
+++ b/apps/ui/src/hooks/useLibraryDisplay.spec.tsx
@@ -1,0 +1,71 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useMediaServerLibraries } from '../api/media-server'
+import { useLibraryDisplay } from './useLibraryDisplay'
+
+vi.mock('../api/media-server', () => ({
+  useMediaServerLibraries: vi.fn(),
+}))
+
+const mockHook = (overrides: {
+  data?: { id: string; title: string; type: string }[]
+  isError?: boolean
+}) => {
+  vi.mocked(useMediaServerLibraries).mockReturnValue({
+    data: overrides.data,
+    isError: overrides.isError ?? false,
+  } as unknown as ReturnType<typeof useMediaServerLibraries>)
+}
+
+describe('useLibraryDisplay', () => {
+  beforeEach(() => {
+    vi.mocked(useMediaServerLibraries).mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('resolves the stored libraryId to a title when present', () => {
+    mockHook({
+      data: [{ id: 'library-1', title: 'Movies', type: 'movie' }],
+    })
+
+    const { result } = renderHook(() => useLibraryDisplay('library-1'))
+
+    expect(result.current.title).toBe('Movies')
+    expect(result.current.hasLibraryId).toBe(true)
+    expect(result.current.isUnreachable).toBe(false)
+  })
+
+  it('flags an unreachable server when the query errored and the id is unresolved', () => {
+    mockHook({ data: undefined, isError: true })
+
+    const { result } = renderHook(() => useLibraryDisplay('library-1'))
+
+    expect(result.current.title).toBeUndefined()
+    expect(result.current.hasLibraryId).toBe(true)
+    expect(result.current.isUnreachable).toBe(true)
+  })
+
+  it('does not flag unreachable when the query succeeded but the library is gone', () => {
+    mockHook({
+      data: [{ id: 'library-2', title: 'Shows', type: 'show' }],
+      isError: false,
+    })
+
+    const { result } = renderHook(() => useLibraryDisplay('library-1'))
+
+    expect(result.current.title).toBeUndefined()
+    expect(result.current.isUnreachable).toBe(false)
+  })
+
+  it('returns hasLibraryId=false for empty identifiers', () => {
+    mockHook({ data: [], isError: false })
+
+    const { result } = renderHook(() => useLibraryDisplay(''))
+
+    expect(result.current.hasLibraryId).toBe(false)
+    expect(result.current.isUnreachable).toBe(false)
+  })
+})

--- a/apps/ui/src/hooks/useLibraryDisplay.ts
+++ b/apps/ui/src/hooks/useLibraryDisplay.ts
@@ -1,0 +1,26 @@
+import { useMediaServerLibraries } from '../api/media-server'
+
+export interface LibraryDisplay {
+  title: string | undefined
+  hasLibraryId: boolean
+  isUnreachable: boolean
+}
+
+/**
+ * Resolves a stored libraryId to a display title while distinguishing an
+ * unreachable media server from a missing selection. Consumers render their
+ * own fallback copy, but the detection logic stays consistent.
+ */
+export function useLibraryDisplay(
+  libraryId: string | number | null | undefined,
+): LibraryDisplay {
+  const { data: libraries, isError: librariesError } = useMediaServerLibraries()
+
+  const hasLibraryId = libraryId != null && libraryId !== ''
+  const title = hasLibraryId
+    ? libraries?.find((lib) => String(lib.id) === String(libraryId))?.title
+    : undefined
+  const isUnreachable = hasLibraryId && !title && librariesError
+
+  return { title, hasLibraryId, isUnreachable }
+}


### PR DESCRIPTION
Addresses #2659.

## Summary
- `GET /media-server/libraries` returns 503 when the server is configured but `getStatus()` fails, so the UI can tell unreachable apart from an empty library list.
- Shared `useLibraryDisplay` hook drives the `Unavailable` label on both rule group and collection cards.
- `AddModal` keeps the stored library as a fallback option, surfaces an inline warning, no longer drops `*arr` rules when the user re-selects the existing library, and renders immediately on cold load when editing.
- `useMediaServerLibraries` uses `retry: 1` so unreachable servers surface in ~1s instead of blocking behind the default 3 retries.

Problems 2 and 3 from the issue are intentionally not touched: `getRuleConstants` only checks DB existence (not reachability), and rule execution genuinely needs the media server to enumerate content (PR #2661 already handles Plex rediscovery).

## Test plan
- [ ] Rule group and collection cards render `Unavailable` for a stored library while Plex is offline
- [ ] Edit modal opens on a cold load with the media server offline, shows the warning, preserves the stored library, and keeps `*arr` rules intact on save
- [ ] Changing to a different library still resets `*arr` rules as before