### PR TITLE
fix: scope rule/collection pre-flight to media server only (#2581)

### DIFF
--- a/apps/server/src/modules/collections/collection-worker.server.spec.ts
+++ b/apps/server/src/modules/collections/collection-worker.server.spec.ts
@@ -7,6 +7,7 @@ import {
   createCollection,
   createCollectionMedia,
 } from '../../../test/utils/data';
+import { MediaServerFactory } from '../api/media-server/media-server.factory';
 import { SeerrApiService } from '../api/seerr-api/seerr-api.service';
 import { MaintainerrLogger } from '../logging/logs.service';
 import { SettingsService } from '../settings/settings.service';
@@ -31,6 +32,7 @@ describe('CollectionWorkerService', () => {
   let executionLock: Mocked<ExecutionLockService>;
   let eventEmitter: Mocked<EventEmitter2>;
   let logger: Mocked<MaintainerrLogger>;
+  let mediaServerFactory: Mocked<MediaServerFactory>;
 
   beforeEach(async () => {
     const { unit, unitRef } = await TestBed.solitary(
@@ -51,9 +53,11 @@ describe('CollectionWorkerService', () => {
     executionLock = unitRef.get(ExecutionLockService);
     eventEmitter = unitRef.get(EventEmitter2);
     logger = unitRef.get(MaintainerrLogger);
+    mediaServerFactory = unitRef.get(MediaServerFactory);
 
     executionLock.acquire.mockResolvedValue(jest.fn());
     eventEmitter.emit.mockImplementation();
+    mediaServerFactory.verifyConnection.mockResolvedValue({} as any);
   });
 
   it('should abort if another instance is running', async () => {
@@ -64,8 +68,10 @@ describe('CollectionWorkerService', () => {
     expect(executionLock.acquire).not.toHaveBeenCalled();
   });
 
-  it('should abort if testing connection fails', async () => {
-    settings.testConnections.mockResolvedValue(false);
+  it('should abort if the media server is unreachable', async () => {
+    mediaServerFactory.verifyConnection.mockRejectedValue(
+      new Error('Media server still unreachable after re-initialization'),
+    );
 
     await collectionWorkerService.execute();
 

--- a/apps/server/src/modules/collections/collection-worker.service.ts
+++ b/apps/server/src/modules/collections/collection-worker.service.ts
@@ -52,17 +52,6 @@ export class CollectionWorkerService extends TaskBase {
   }
 
   protected async executeTask() {
-    // Pre-flight: verify media server is reachable (triggers re-discovery for Plex)
-    try {
-      await this.mediaServerFactory.verifyConnection();
-    } catch (error) {
-      this.logger.warn(
-        'Media server unreachable, skipping collection handler run',
-      );
-      this.logger.debug(error);
-      return;
-    }
-
     this.eventEmitter.emit(
       MaintainerrEvent.CollectionHandler_Started,
       new CollectionHandlerStartedEventDto(
@@ -75,14 +64,19 @@ export class CollectionWorkerService extends TaskBase {
     let failed = false;
 
     try {
-      // Start actual task
-      const appStatus = await this.settings.testConnections();
-
-      if (!appStatus) {
+      // Verify the only hard dependency for collection handling: the media
+      // server. Ancillary services (Radarr/Sonarr/Seerr/Tautulli) are
+      // exercised at the call site by the handler, so a transient blip in
+      // an unrelated backend must not abort the whole run. Plex auto
+      // re-discovery is handled inside verifyConnection().
+      try {
+        await this.mediaServerFactory.verifyConnection();
+      } catch (error) {
         failed = true;
         this.logger.log(
-          'Not all applications are reachable.. Skipping collection handling',
+          'Media server unreachable. Skipping collection handling.',
         );
+        this.logger.debug(error);
         return;
       }
 

--- a/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.spec.ts
@@ -1,8 +1,12 @@
 import { createMockLogger } from '../../../../test/utils/data';
 import { ExecutionLockService } from '../../tasks/execution-lock.service';
 import { RuleExecutorJobManagerService } from './rule-executor-job-manager.service';
+import { RuleExecutionResult } from './rule-executor.service';
 
-type ExecuteMock = jest.Mock<Promise<void>, [number, AbortSignal]>;
+type ExecuteMock = jest.Mock<
+  Promise<RuleExecutionResult>,
+  [number, AbortSignal]
+>;
 
 const createDeferred = () => {
   let resolve: () => void;
@@ -23,7 +27,8 @@ describe('RuleExecutorJobManagerService', () => {
   const buildService = (executeMock?: ExecuteMock) => {
     const ruleExecutorService = {
       executeForRuleGroups:
-        executeMock ?? (jest.fn().mockResolvedValue(undefined) as ExecuteMock),
+        executeMock ??
+        (jest.fn().mockResolvedValue({ status: 'success' }) as ExecuteMock),
     };
 
     const eventEmitter = {
@@ -72,6 +77,7 @@ describe('RuleExecutorJobManagerService', () => {
           await second.promise;
         }
         inFlight.pop();
+        return { status: 'success' };
       });
 
     const { service } = buildService(executeMock);
@@ -101,9 +107,10 @@ describe('RuleExecutorJobManagerService', () => {
 
   it('aborts the currently executing job when requested', async () => {
     const executionDeferred = createDeferred();
-    const executeMock: ExecuteMock = jest
-      .fn()
-      .mockImplementation(async () => executionDeferred.promise);
+    const executeMock: ExecuteMock = jest.fn().mockImplementation(async () => {
+      await executionDeferred.promise;
+      return { status: 'success' };
+    });
 
     const { service } = buildService(executeMock);
 
@@ -122,8 +129,98 @@ describe('RuleExecutorJobManagerService', () => {
     await flushMicrotasks();
   });
 
+  it('drops the whole queue silently when the media server is unreachable at queue start', async () => {
+    const executeMock: ExecuteMock = jest
+      .fn()
+      .mockResolvedValue({ status: 'success' });
+    const { service, mediaServerFactory, eventEmitter } =
+      buildService(executeMock);
+
+    mediaServerFactory.verifyConnection.mockRejectedValue(
+      new Error('Media server still unreachable after re-initialization'),
+    );
+
+    service.enqueue({ ruleGroupId: 1 });
+    service.enqueue({ ruleGroupId: 2 });
+    service.enqueue({ ruleGroupId: 3 });
+
+    await flushMicrotasks();
+    await waitForNextTick();
+    await flushMicrotasks();
+
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(service.getQueuedRuleGroupIds()).toHaveLength(0);
+    expect(service.isProcessing()).toBe(false);
+
+    const failedEvents = eventEmitter.emit.mock.calls.filter(
+      ([eventName]) => eventName === 'rule-handler.failed',
+    );
+    expect(failedEvents).toHaveLength(0);
+  });
+
+  it('drops remaining queued rule groups after the first mid-queue media server outage', async () => {
+    const executeMock: ExecuteMock = jest
+      .fn()
+      .mockResolvedValueOnce({ status: 'success' })
+      .mockResolvedValueOnce({
+        status: 'failed',
+        failedPayload: {
+          collectionName: 'Movies',
+          identifier: { type: 'rulegroup', value: 2 },
+        } as any,
+        reason: 'media-server-unreachable',
+      });
+
+    const { service } = buildService(executeMock);
+
+    service.enqueue({ ruleGroupId: 1 });
+    service.enqueue({ ruleGroupId: 2 });
+    service.enqueue({ ruleGroupId: 3 });
+
+    await flushMicrotasks();
+    await waitForNextTick();
+    await flushMicrotasks();
+    await waitForNextTick();
+    await flushMicrotasks();
+
+    expect(executeMock).toHaveBeenCalledTimes(2);
+    expect(executeMock).toHaveBeenNthCalledWith(1, 1, expect.any(AbortSignal));
+    expect(executeMock).toHaveBeenNthCalledWith(2, 2, expect.any(AbortSignal));
+    expect(service.getQueuedRuleGroupIds()).toEqual([]);
+    expect(service.isProcessing()).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Media server became unreachable during queue execution. Dropping remaining queued rule groups.',
+    );
+  });
+
+  it('does not log a queue-drain warning when the last executing rule fails from a media server outage', async () => {
+    const executeMock: ExecuteMock = jest.fn().mockResolvedValue({
+      status: 'failed',
+      failedPayload: {
+        collectionName: 'Movies',
+        identifier: { type: 'rulegroup', value: 1 },
+      } as any,
+      reason: 'media-server-unreachable',
+    });
+
+    const { service } = buildService(executeMock);
+
+    service.enqueue({ ruleGroupId: 1 });
+
+    await flushMicrotasks();
+    await waitForNextTick();
+    await flushMicrotasks();
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      'Media server became unreachable during queue execution. Dropping remaining queued rule groups.',
+    );
+  });
+
   it('clears queued work when stopProcessing is called', async () => {
-    const executeMock: ExecuteMock = jest.fn().mockResolvedValue(undefined);
+    const executeMock: ExecuteMock = jest
+      .fn()
+      .mockResolvedValue({ status: 'success' });
     const { service } = buildService(executeMock);
 
     service.enqueue({ ruleGroupId: 1 });
@@ -137,9 +234,10 @@ describe('RuleExecutorJobManagerService', () => {
 
   it('reports status correctly', async () => {
     const inFlight = createDeferred();
-    const executeMock: ExecuteMock = jest
-      .fn()
-      .mockImplementation(() => inFlight.promise);
+    const executeMock: ExecuteMock = jest.fn().mockImplementation(async () => {
+      await inFlight.promise;
+      return { status: 'success' };
+    });
     const { service } = buildService(executeMock);
 
     expect(service.getStatus()).toEqual({
@@ -164,7 +262,9 @@ describe('RuleExecutorJobManagerService', () => {
   it('reports a rule group as pending while waiting for the execution lock', async () => {
     const lockDeferred = createDeferred();
     const release = jest.fn();
-    const executeMock: ExecuteMock = jest.fn().mockResolvedValue(undefined);
+    const executeMock: ExecuteMock = jest
+      .fn()
+      .mockResolvedValue({ status: 'success' });
 
     const { service, executionLock, eventEmitter } = buildService(executeMock);
     jest.spyOn(executionLock, 'acquire').mockImplementation(async () => {
@@ -210,7 +310,9 @@ describe('RuleExecutorJobManagerService', () => {
   it('preserves an abort request while waiting for the execution lock', async () => {
     const lockDeferred = createDeferred();
     const release = jest.fn();
-    const executeMock: ExecuteMock = jest.fn().mockResolvedValue(undefined);
+    const executeMock: ExecuteMock = jest
+      .fn()
+      .mockResolvedValue({ status: 'success' });
 
     const { service, executionLock } = buildService(executeMock);
     jest.spyOn(executionLock, 'acquire').mockImplementation(async () => {

--- a/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor-job-manager.service.ts
@@ -7,7 +7,10 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { MediaServerFactory } from '../../api/media-server/media-server.factory';
 import { MaintainerrLogger } from '../../logging/logs.service';
 import { ExecutionLockService } from '../../tasks/execution-lock.service';
-import { RuleExecutorService } from './rule-executor.service';
+import {
+  RuleExecutorService,
+  type RuleExecutionResult,
+} from './rule-executor.service';
 
 type QueueItem = {
   ruleGroupId: number;
@@ -163,7 +166,11 @@ export class RuleExecutorJobManagerService implements OnApplicationShutdown {
     this.processingQueue = true;
     this.processQueuePromise = (async () => {
       try {
-        // Pre-flight: verify media server is reachable (triggers re-discovery for Plex)
+        // Queue-level pre-flight: if the media server is unreachable at the
+        // start of the run, silently drop the whole queue to avoid spamming
+        // per-rule failure notifications during a sustained outage. The
+        // per-rule check inside RuleExecutorService still handles transient
+        // blips that occur between rules in a long run.
         try {
           await this.mediaServerFactory.verifyConnection();
         } catch (error) {
@@ -207,10 +214,11 @@ export class RuleExecutorJobManagerService implements OnApplicationShutdown {
       this.emitStatusUpdate();
 
       try {
-        await this.ruleExecutorService.executeForRuleGroups(
+        const result = await this.ruleExecutorService.executeForRuleGroups(
           request.ruleGroupId,
           this.abortController.signal,
         );
+        this.handleQueueLevelFailure(result);
       } catch (error) {
         this.logger.error(
           `An error occurred while executing job for rule group ${request.ruleGroupId}`,
@@ -225,6 +233,23 @@ export class RuleExecutorJobManagerService implements OnApplicationShutdown {
       this.reservedRuleGroupIds.delete(request.ruleGroupId);
       this.emitStatusUpdate();
     }
+  }
+
+  private handleQueueLevelFailure(result: RuleExecutionResult) {
+    if (
+      result.status !== 'failed' ||
+      result.reason !== 'media-server-unreachable'
+    ) {
+      return;
+    }
+
+    if (this.queue.length > 0) {
+      this.logger.warn(
+        'Media server became unreachable during queue execution. Dropping remaining queued rule groups.',
+      );
+    }
+    this.queue.length = 0;
+    this.emitStatusUpdate();
   }
 
   public getStatus() {

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.spec.ts
@@ -29,6 +29,7 @@ describe('RuleExecutorService', () => {
 
     const mediaServerFactory = {
       getService: jest.fn().mockResolvedValue(mediaServer),
+      verifyConnection: jest.fn().mockResolvedValue(mediaServer),
     } as unknown as jest.Mocked<MediaServerFactory>;
 
     const collectionService = {
@@ -88,7 +89,6 @@ describe('RuleExecutorService', () => {
 
     const settings = {
       media_server_type: mediaServerType,
-      testConnections: jest.fn().mockResolvedValue(true),
       testSetup: jest.fn().mockResolvedValue(true),
     } as unknown as jest.Mocked<SettingsService>;
 
@@ -821,13 +821,54 @@ describe('RuleExecutorService', () => {
     expect(progressManager.reset).toHaveBeenCalled();
   });
 
+  it('fails the rule group when the media server is unreachable', async () => {
+    const { service, rulesService, mediaServerFactory, eventEmitter, logger } =
+      createService(MediaServerType.PLEX);
+
+    const ruleGroup = {
+      id: 55,
+      name: 'Reduce movie quality',
+      isActive: true,
+      libraryId: 'library-1',
+      useRules: true,
+      rules: [],
+      collectionId: 1,
+      collection: { title: 'Movies' },
+    };
+
+    rulesService.getRuleGroup.mockResolvedValue(ruleGroup as any);
+    mediaServerFactory.verifyConnection.mockRejectedValue(
+      new Error('Media server still unreachable after re-initialization'),
+    );
+
+    await expect(
+      service.executeForRuleGroups(55, new AbortController().signal),
+    ).resolves.toEqual({
+      status: 'failed',
+      failedPayload: expect.objectContaining({
+        collectionName: 'Movies',
+        identifier: { type: 'rulegroup', value: 55 },
+      }),
+      reason: 'media-server-unreachable',
+    });
+
+    expect(mediaServerFactory.verifyConnection).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Media server unreachable. Skipping execution of rule 'Reduce movie quality'.",
+    );
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      MaintainerrEvent.RuleHandler_Failed,
+      expect.anything(),
+    );
+  });
+
   it('does not emit started and still cleans up when execution was already aborted before starting', async () => {
     const {
       service,
       rulesService,
       eventEmitter,
       progressManager,
-      settings,
+      mediaServerFactory,
       logger,
     } = createService(MediaServerType.JELLYFIN);
 
@@ -851,7 +892,7 @@ describe('RuleExecutorService', () => {
       MaintainerrEvent.RuleHandler_Started,
       expect.anything(),
     );
-    expect(settings.testConnections).not.toHaveBeenCalled();
+    expect(mediaServerFactory.verifyConnection).not.toHaveBeenCalled();
     expect(logger.log).toHaveBeenCalledWith(
       "Execution of rule 'Aborted Group' was aborted.",
     );

--- a/apps/server/src/modules/rules/tasks/rule-executor.service.ts
+++ b/apps/server/src/modules/rules/tasks/rule-executor.service.ts
@@ -55,15 +55,22 @@ interface CollectionMembershipSyncChanges {
   removedMediaServerIds: Set<string>;
 }
 
+export type RuleExecutionFailureReason = 'media-server-unreachable';
+
 export type RuleExecutionResult =
   | { status: 'success' }
-  | { status: 'failed'; failedPayload: RuleHandlerFailedDto }
+  | {
+      status: 'failed';
+      failedPayload: RuleHandlerFailedDto;
+      reason?: RuleExecutionFailureReason;
+    }
   | { status: 'aborted' }
   | { status: 'skipped'; reason: 'not-found' | 'inactive' };
 
 class RuleExecutionFailure extends Error {
   constructor(
     public readonly payload: RuleHandlerFailedDto,
+    public readonly reason?: RuleExecutionFailureReason,
     message?: string,
   ) {
     super(message ?? 'Rule execution failed');
@@ -170,94 +177,100 @@ export class RuleExecutorService {
         );
       }
 
-      const appStatus = await this.settings.testConnections();
+      // Verify the only hard dependency for rule execution: the media server.
+      // Ancillary services (Radarr/Sonarr/Seerr/Tautulli) are exercised at the
+      // call site by the rules that actually use them, so a transient blip in
+      // an unrelated backend must not abort the whole rule run. Plex auto
+      // re-discovery is handled inside verifyConnection().
+      try {
+        await this.mediaServerFactory.verifyConnection();
+      } catch (error) {
+        this.logger.warn(
+          `Media server unreachable. Skipping execution of rule '${ruleGroup.name}'.`,
+        );
+        this.logger.debug(error);
+        throw new RuleExecutionFailure(
+          this.buildRuleHandlerFailedDto(ruleGroup),
+          'media-server-unreachable',
+        );
+      }
 
-      if (appStatus) {
-        // reset API caches, make sure latest data is used
-        cacheManager.flushAll();
+      // reset API caches, make sure latest data is used
+      cacheManager.flushAll();
 
-        const comparator = this.comparatorFactory.create();
-        const mediaServer = await this.getMediaServer();
+      const comparator = this.comparatorFactory.create();
+      const mediaServer = await this.getMediaServer();
 
-        const mediaItemCount = await mediaServer.getLibraryContentCount(
-          ruleGroup.libraryId.toString(),
-          ruleGroup.dataType ? ruleGroup.dataType : undefined,
+      const mediaItemCount = await mediaServer.getLibraryContentCount(
+        ruleGroup.libraryId.toString(),
+        ruleGroup.dataType ? ruleGroup.dataType : undefined,
+      );
+
+      const totalEvaluations = mediaItemCount * ruleGroup.rules.length;
+
+      this.progressManager.initialize({
+        name: ruleGroup.name,
+        totalEvaluations: totalEvaluations,
+      });
+
+      let collectionSyncChanges: CollectionMembershipSyncChanges = {
+        addedMediaServerIds: new Set<string>(),
+        removedMediaServerIds: new Set<string>(),
+      };
+
+      if (ruleGroup.useRules) {
+        this.logger.log(`Executing rules for '${ruleGroup.name}'`);
+        this.startTime = new Date();
+
+        // reset media server cache if group uses a rule that requires it (collection rules for example)
+        await this.rulesService.resetCacheIfGroupUsesRuleThatRequiresIt(
+          ruleGroup,
         );
 
-        const totalEvaluations = mediaItemCount * ruleGroup.rules.length;
+        // prepare
+        this.workerData = [];
+        this.resultData = [];
+        this.statisticsData = [];
+        this.mediaData = { page: 0, finished: false, data: [] };
 
-        this.progressManager.initialize({
-          name: ruleGroup.name,
-          totalEvaluations: totalEvaluations,
-        });
+        this.mediaDataType = ruleGroup.dataType || undefined;
 
-        let collectionSyncChanges: CollectionMembershipSyncChanges = {
-          addedMediaServerIds: new Set<string>(),
-          removedMediaServerIds: new Set<string>(),
-        };
-
-        if (ruleGroup.useRules) {
-          this.logger.log(`Executing rules for '${ruleGroup.name}'`);
-          this.startTime = new Date();
-
-          // reset media server cache if group uses a rule that requires it (collection rules for example)
-          await this.rulesService.resetCacheIfGroupUsesRuleThatRequiresIt(
-            ruleGroup,
-          );
-
-          // prepare
-          this.workerData = [];
-          this.resultData = [];
-          this.statisticsData = [];
-          this.mediaData = { page: 0, finished: false, data: [] };
-
-          this.mediaDataType = ruleGroup.dataType || undefined;
-
-          // Run rules data chunks of 50
-          while (!this.mediaData.finished) {
-            abortSignal.throwIfAborted();
-            await this.getMediaData(ruleGroup.libraryId);
-
-            const ruleResult = await comparator.executeRulesWithData(
-              ruleGroup,
-              this.mediaData.data,
-              () => {
-                this.progressManager.incrementProcessed(
-                  this.mediaData.data.length,
-                );
-              },
-              abortSignal,
-            );
-
-            if (ruleResult) {
-              this.statisticsData.push(...ruleResult.stats);
-              this.resultData.push(...ruleResult.data);
-            }
-          }
-
+        // Run rules data chunks of 50
+        while (!this.mediaData.finished) {
           abortSignal.throwIfAborted();
-          collectionSyncChanges = await this.handleCollection(
-            await this.rulesService.getRuleGroupById(ruleGroup.id), // refetch to get latest changes
+          await this.getMediaData(ruleGroup.libraryId);
+
+          const ruleResult = await comparator.executeRulesWithData(
+            ruleGroup,
+            this.mediaData.data,
+            () => {
+              this.progressManager.incrementProcessed(
+                this.mediaData.data.length,
+              );
+            },
             abortSignal,
           );
 
-          this.logger.log(`Execution of rules for '${ruleGroup.name}' done.`);
+          if (ruleResult) {
+            this.statisticsData.push(...ruleResult.stats);
+            this.resultData.push(...ruleResult.data);
+          }
         }
 
         abortSignal.throwIfAborted();
-        await this.syncManualMediaServerToCollectionDB(
+        collectionSyncChanges = await this.handleCollection(
           await this.rulesService.getRuleGroupById(ruleGroup.id), // refetch to get latest changes
-          collectionSyncChanges,
-        );
-      } else {
-        this.logger.warn(
-          'Not all applications are reachable.. Skipped rule execution.',
+          abortSignal,
         );
 
-        throw new RuleExecutionFailure(
-          this.buildRuleHandlerFailedDto(ruleGroup),
-        );
+        this.logger.log(`Execution of rules for '${ruleGroup.name}' done.`);
       }
+
+      abortSignal.throwIfAborted();
+      await this.syncManualMediaServerToCollectionDB(
+        await this.rulesService.getRuleGroupById(ruleGroup.id), // refetch to get latest changes
+        collectionSyncChanges,
+      );
     } catch (error) {
       const executionBeingAborted =
         error instanceof DOMException && error.name === 'AbortError';
@@ -265,7 +278,11 @@ export class RuleExecutorService {
       if (!executionBeingAborted) {
         if (error instanceof RuleExecutionFailure) {
           failedPayload = error.payload;
-          result = { status: 'failed', failedPayload: error.payload };
+          result = {
+            status: 'failed',
+            failedPayload: error.payload,
+            ...(error.reason ? { reason: error.reason } : undefined),
+          };
         } else {
           this.logger.error('Error running rules executor.');
           this.logger.debug(error);


### PR DESCRIPTION
Closes #2581.

## Problem

Rule execution called `settings.testConnections()` once per rule, probing **every** configured backend (media server, all *arrs, Seerr, Tautulli) with a hard 5s timeout. Any single transient blip skipped the rule — including rules that didn't use the failing backend. Same issue in `CollectionWorkerService`.

## Fix

Replace the global gate with a narrow `mediaServerFactory.verifyConnection()` check against the only hard dependency. Ancillary services are exercised at their call sites, so their failures no longer cascade.

Layered checks with distinct semantics:

- **Queue-level pre-flight** (silent drop) — sustained outages, no Discord spam.
- **Per-rule check** (noisy) — between-rule flakiness in long runs.
- **Mid-queue outage handling** — typed `reason: 'media-server-unreachable'` on the failure result lets the job manager drop the rest of the queue silently after the first failure reports once.

## Test plan

- [x] `rule-executor.service.spec.ts` — new test for per-rule media-server-unreachable path
- [x] `rule-executor-job-manager.service.spec.ts` — new tests for queue-start and mid-queue outage paths
- [x] `collection-worker.server.spec.ts` — updated abort test to use `verifyConnection`
- [x] All 36 tests pass across the three suites
- [ ] Manual: trigger "Run all rules" with Seerr unreachable, confirm rules that don't use Seerr still execute