### PR TITLE
fix: count Sonarr monitored episodes accurately

### DIFF
--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.spec.ts
@@ -246,6 +246,276 @@ describe('SonarrGetterService', () => {
     });
   });
 
+  describe('seasons_monitored', () => {
+    it('returns monitored episode count for a season even when all episodes have files', async () => {
+      const collectionMedia = createCollectionMedia('season');
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      mockMediaServer.getMetadata.mockResolvedValue(
+        createMediaItem({
+          type: 'show',
+        }),
+      );
+
+      const series = createSonarrSeries({
+        seasons: [
+          {
+            seasonNumber: 0,
+            monitored: false,
+          },
+          {
+            seasonNumber: 6,
+            monitored: true,
+            statistics: {
+              episodeCount: 10,
+              episodeFileCount: 10,
+              totalEpisodeCount: 10,
+              sizeOnDisk: 0,
+              percentOfEpisodes: 100,
+            },
+          },
+        ],
+      });
+
+      const mockedSonarrApi = mockSonarrApi(series);
+      jest.spyOn(mockedSonarrApi, 'getEpisodes').mockResolvedValue(
+        Array.from({ length: 10 }, (_, index) =>
+          createSonarrEpisode({
+            seriesId: series.id,
+            seasonNumber: 6,
+            episodeNumber: index + 1,
+            monitored: false,
+            hasFile: true,
+          }),
+        ),
+      );
+
+      const response = await sonarrGetterService.get(
+        11,
+        createMediaItem({
+          type: 'season',
+          index: 6,
+        }),
+        'season',
+        createRulesDto({
+          collection: collectionMedia.collection,
+          dataType: 'season',
+        }),
+      );
+
+      expect(response).toBe(0);
+      expect(mockedSonarrApi.getEpisodes).toHaveBeenCalledWith(series.id, 6);
+    });
+
+    it('returns monitored episode count for a season even when only some monitored episodes have files', async () => {
+      const collectionMedia = createCollectionMedia('season');
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      mockMediaServer.getMetadata.mockResolvedValue(
+        createMediaItem({
+          type: 'show',
+        }),
+      );
+
+      const series = createSonarrSeries({
+        seasons: [
+          {
+            seasonNumber: 0,
+            monitored: false,
+          },
+          {
+            seasonNumber: 8,
+            monitored: true,
+            statistics: {
+              episodeCount: 2,
+              episodeFileCount: 2,
+              totalEpisodeCount: 10,
+              sizeOnDisk: 0,
+              percentOfEpisodes: 20,
+            },
+          },
+        ],
+      });
+
+      const mockedSonarrApi = mockSonarrApi(series);
+      jest.spyOn(mockedSonarrApi, 'getEpisodes').mockResolvedValue(
+        Array.from({ length: 10 }, (_, index) =>
+          createSonarrEpisode({
+            seriesId: series.id,
+            seasonNumber: 8,
+            episodeNumber: index + 1,
+            monitored: true,
+            hasFile: index < 2,
+          }),
+        ),
+      );
+
+      const response = await sonarrGetterService.get(
+        11,
+        createMediaItem({
+          type: 'season',
+          index: 8,
+        }),
+        'season',
+        createRulesDto({
+          collection: collectionMedia.collection,
+          dataType: 'season',
+        }),
+      );
+
+      expect(response).toBe(10);
+      expect(mockedSonarrApi.getEpisodes).toHaveBeenCalledWith(series.id, 8);
+    });
+
+    it('returns the season monitored episode count for episode rules', async () => {
+      const collectionMedia = createCollectionMedia('episode');
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      mockMediaServer.getMetadata.mockResolvedValue(
+        createMediaItem({
+          type: 'show',
+        }),
+      );
+
+      const series = createSonarrSeries({
+        seasons: [
+          {
+            seasonNumber: 0,
+            monitored: false,
+          },
+          {
+            seasonNumber: 4,
+            monitored: true,
+            statistics: {
+              episodeCount: 3,
+              episodeFileCount: 1,
+              totalEpisodeCount: 10,
+              sizeOnDisk: 0,
+              percentOfEpisodes: 30,
+            },
+          },
+        ],
+      });
+
+      const mockedSonarrApi = mockSonarrApi(series);
+      jest.spyOn(mockedSonarrApi, 'getEpisodes').mockResolvedValue(
+        Array.from({ length: 10 }, (_, index) =>
+          createSonarrEpisode({
+            seriesId: series.id,
+            seasonNumber: 4,
+            episodeNumber: index + 1,
+            monitored: index < 3,
+            hasFile: index === 0,
+          }),
+        ),
+      );
+
+      const response = await sonarrGetterService.get(
+        11,
+        createMediaItem({
+          type: 'episode',
+          index: 1,
+          parentIndex: 4,
+          parentId: 'season-4',
+          grandparentId: 'show-1',
+        }),
+        'episode',
+        createRulesDto({
+          collection: collectionMedia.collection,
+          dataType: 'episode',
+        }),
+      );
+
+      expect(response).toBe(3);
+      expect(mockedSonarrApi.getEpisodes).toHaveBeenCalledWith(series.id, 4);
+    });
+  });
+
+  describe('finale properties', () => {
+    it('returns season finale state for season rules', async () => {
+      const collectionMedia = createCollectionMedia('season');
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      mockMediaServer.getMetadata.mockResolvedValue(
+        createMediaItem({
+          type: 'show',
+        }),
+      );
+
+      const series = createSonarrSeries({
+        seasons: [
+          {
+            seasonNumber: 0,
+            monitored: false,
+          },
+          {
+            seasonNumber: 5,
+            monitored: true,
+          },
+        ],
+      });
+
+      const mockedSonarrApi = mockSonarrApi(series);
+      jest.spyOn(mockedSonarrApi, 'getEpisodes').mockResolvedValue([
+        createSonarrEpisode({
+          seriesId: series.id,
+          seasonNumber: 5,
+          episodeNumber: 10,
+          finaleType: 'season',
+          hasFile: true,
+        }),
+      ]);
+
+      const response = await sonarrGetterService.get(
+        16,
+        createMediaItem({
+          type: 'season',
+          index: 5,
+        }),
+        'season',
+        createRulesDto({
+          collection: collectionMedia.collection,
+          dataType: 'season',
+        }),
+      );
+
+      expect(response).toBe(true);
+      expect(mockedSonarrApi.getEpisodes).toHaveBeenCalledWith(series.id, 5);
+    });
+
+    it('returns series finale state for show rules', async () => {
+      const collectionMedia = createCollectionMedia('show');
+      collectionMedia.collection.sonarrSettingsId = 1;
+
+      const series = createSonarrSeries();
+      const mockedSonarrApi = mockSonarrApi(series);
+      jest.spyOn(mockedSonarrApi, 'getEpisodes').mockResolvedValue([
+        createSonarrEpisode({
+          seriesId: series.id,
+          seasonNumber: 5,
+          episodeNumber: 10,
+          finaleType: 'series',
+          hasFile: true,
+        }),
+      ]);
+
+      const response = await sonarrGetterService.get(
+        17,
+        createMediaItem({
+          type: 'show',
+        }),
+        'show',
+        createRulesDto({
+          collection: collectionMedia.collection,
+          dataType: 'show',
+        }),
+      );
+
+      expect(response).toBe(true);
+      expect(mockedSonarrApi.getEpisodes).toHaveBeenCalledWith(series.id);
+    });
+  });
+
   describe('episode file properties', () => {
     let collectionMedia: CollectionMedia;
     let mockedSonarrApi: SonarrApi;

--- a/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
+++ b/apps/server/src/modules/rules/getter/sonarr-getter.service.ts
@@ -12,12 +12,12 @@ import { MediaServerFactory } from '../../api/media-server/media-server.factory'
 import { IMediaServerService } from '../../api/media-server/media-server.interface';
 import { SonarrApi } from '../../api/servarr-api/helpers/sonarr.helper';
 import { MaintainerrLogger } from '../../logging/logs.service';
-import { MetadataService } from '../../metadata/metadata.service';
 import {
   findMetadataLookupMatch,
   formatMetadataLookupCandidates,
   MetadataLookupCandidate,
 } from '../../metadata/metadata-lookup.util';
+import { MetadataService } from '../../metadata/metadata.service';
 import {
   Application,
   Property,
@@ -188,6 +188,47 @@ export class SonarrGetterService {
         return episodeFilePromise;
       };
 
+      let seasonEpisodesPromise:
+        | Promise<SonarrEpisode[] | undefined>
+        | undefined;
+      const getSeasonEpisodes = async (): Promise<
+        SonarrEpisode[] | undefined
+      > => {
+        if (dataType !== 'season' && dataType !== 'episode') {
+          return undefined;
+        }
+
+        if (showResponse.added === '0001-01-01T00:00:00Z') {
+          return undefined;
+        }
+
+        if (!showResponse.id || !origLibItem) {
+          return undefined;
+        }
+
+        seasonEpisodesPromise ??= sonarrApiClient.getEpisodes(
+          showResponse.id,
+          origLibItem.grandparentId
+            ? origLibItem.parentIndex
+            : origLibItem.index,
+        );
+
+        return seasonEpisodesPromise;
+      };
+
+      let showEpisodesPromise: Promise<SonarrEpisode[] | undefined> | undefined;
+      const getShowEpisodes = async (): Promise<
+        SonarrEpisode[] | undefined
+      > => {
+        if (!showResponse.id) {
+          return undefined;
+        }
+
+        showEpisodesPromise ??= sonarrApiClient.getEpisodes(showResponse.id);
+
+        return showEpisodesPromise;
+      };
+
       switch (prop.name) {
         case 'addDate': {
           return showResponse.added &&
@@ -313,10 +354,13 @@ export class SonarrGetterService {
         case 'seasons_monitored': {
           // returns the number of monitored seasons / episodes
           if (dataType === 'season' || dataType === 'episode') {
-            return season?.statistics?.episodeCount
-              ? +season.statistics.episodeCount
-              : null;
+            return (
+              (await getSeasonEpisodes())?.filter(
+                (episode) => episode.monitored,
+              ).length ?? null
+            );
           } else {
+            // Show rules intentionally keep the legacy season-count unit; season/episode rules count monitored episodes.
             return showResponse.seasons.filter((el) => el.monitored).length;
           }
         }
@@ -341,22 +385,17 @@ export class SonarrGetterService {
             : null;
         }
         case 'seasonFinale': {
-          const episodes = await sonarrApiClient.getEpisodes(
-            showResponse.id,
-            origLibItem.index,
-          );
-
-          return episodes.some(
+          return (await getSeasonEpisodes())?.some(
             (el) => el.finaleType === 'season' && el.hasFile,
           );
         }
         case 'seriesFinale': {
-          const episodes = await sonarrApiClient.getEpisodes(
-            showResponse.id,
-            dataType === 'season' ? origLibItem.index : undefined,
-          );
+          const episodes =
+            dataType === 'season'
+              ? await getSeasonEpisodes()
+              : await getShowEpisodes();
 
-          return episodes.some(
+          return episodes?.some(
             (el) => el.finaleType === 'series' && el.hasFile,
           );
         }


### PR DESCRIPTION
## Summary
Fix Sonarr season rule evaluation so `Number of monitored seasons / episodes` counts actual monitored episodes instead of Sonarr's mixed `episodeCount` statistic.

## What changed
- count monitored episodes from the Sonarr episode list for season and episode rule contexts
- keep the existing show-level season-count behavior and document the intentional unit mismatch
- add regression coverage for season, episode, and finale getter paths

## Validation
- yarn format
- yarn lint
- yarn test

Closes #1824